### PR TITLE
feat: add validator for the description of a property

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,11 @@ checks:
         changeEnforcement: Strict
         removalEnforcement: Strict
         additionEnforcement: Strict
+      description:
+        enabled: true
+        changeEnforcement: Strict
+        removalEnforcement: Strict
+        additionEnforcement: Strict
       required:
         enabled: true
         newEnforcement: Strict

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,9 +27,6 @@ checks:
         additionEnforcement: Strict
       description:
         enabled: true
-        changeEnforcement: Strict
-        removalEnforcement: Strict
-        additionEnforcement: Strict
       required:
         enabled: true
         newEnforcement: Strict
@@ -83,9 +80,6 @@ checks:
         additionEnforcement: Strict
       description:
         enabled: true
-        changeEnforcement: Strict
-        removalEnforcement: Strict
-        additionEnforcement: Strict
       required:
         enabled: true
         newEnforcement: Strict

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,11 @@ checks:
         changeEnforcement: Strict
         removalEnforcement: Strict
         additionEnforcement: Strict
+      description:
+        enabled: true
+        changeEnforcement: Strict
+        removalEnforcement: Strict
+        additionEnforcement: Strict
       required:
         enabled: true
         newEnforcement: Strict

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -234,7 +234,7 @@ checks:
         # If set to an unknown value, the "Strict" enforcement strategy
         # will be used.
         removalEnforcement: { Strict || None }
-        # AdditionEnforcement is the enforcement strategy that should be used
+        # additionEnforcement is the enforcement strategy that should be used
         # when evaluating if the addition of a default value for a property
         # is considered incompatible.
         #
@@ -244,6 +244,83 @@ checks:
         # is considered incompatible.
         #
         # When set to "None", addition of a default value for a property is
+        # not considered incompatible.
+        #
+        # If set to an unknown value, the "Strict" enforcement strategy
+        # will be used.
+        additionEnforcement: { Strict || None }
+```
+
+### Description
+
+Validates compatibility of changes to a property's description. Changes to descriptions
+of properties can lead to misunderstandings or incorrect usage of the custom resource,
+especially if users rely on the description for guidance.
+
+Incompatible changes are generally:
+
+- Removing the description
+- Changing the description
+- Adding a description when one did not exist previously
+
+In a configuration file, this validation can be configured to:
+
+- Be enabled/disabled
+- Prevent changes to the description
+- Prevent the removal of the description
+- Prevent the addition of a description when one did not previously exist
+
+Example configuration for this validation:
+
+```yaml
+checks:
+  version:
+   # in this example we are configuring the sameVersion validation's enum property validation.
+   # it is possible to configure this property validation separately in both the sameVersion and
+   # servedVersion validations.
+    sameVersion:
+      description:
+        enabled: { true || false }
+        # changeEnforcement is the enforcement strategy that should be used
+        # when evaluating if a change to the description of a property
+        # is considered incompatible.
+        #
+        # Known enforcement strategies are "Strict" and "None".
+        #
+        # When set to "Strict", any changes to the description of a property
+        # is considered incompatible.
+        #
+        # When set to "None", changes to the description of a property are
+        # not considered incompatible.
+        #
+        # If set to an unknown value, the "Strict" enforcement strategy
+        # will be used.
+        changeEnforcement: { Strict || None }
+        # removalEnforcement is the enforcement strategy that should be used
+        # when evaluating if the removal of the description of a property
+        # is considered incompatible.
+        #
+        # Known enforcement strategies are "Strict" and "None".
+        #
+        # When set to "Strict", removal of the description of a property
+        # is considered incompatible.
+        #
+        # When set to "None", removal of the description of a property is
+        # not considered incompatible.
+        #
+        # If set to an unknown value, the "Strict" enforcement strategy
+        # will be used.
+        removalEnforcement: { Strict || None }
+        # additionEnforcement is the enforcement strategy that should be used
+        # when evaluating if the addition of a description for a property
+        # is considered incompatible.
+        #
+        # Known enforcement strategies are "Strict" and "None".
+        #
+        # When set to "Strict", addition of a description for a property
+        # is considered incompatible.
+        #
+        # When set to "None", addition of a description for a property is
         # not considered incompatible.
         #
         # If set to an unknown value, the "Strict" enforcement strategy

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -254,21 +254,8 @@ checks:
 ### Description
 
 Validates compatibility of changes to a property's description. Changes to descriptions
-of properties can lead to misunderstandings or incorrect usage of the custom resource,
-especially if users rely on the description for guidance.
-
-Incompatible changes are generally:
-
-- Removing the description
-- Changing the description
-- Adding a description when one did not exist previously
-
-In a configuration file, this validation can be configured to:
-
-- Be enabled/disabled
-- Prevent changes to the description
-- Prevent the removal of the description
-- Prevent the addition of a description when one did not previously exist
+of properties are generally an acceptable change. If enabled, the validator allows all changes
+to the description of a property.
 
 Example configuration for this validation:
 
@@ -281,51 +268,6 @@ checks:
     sameVersion:
       description:
         enabled: { true || false }
-        # changeEnforcement is the enforcement strategy that should be used
-        # when evaluating if a change to the description of a property
-        # is considered incompatible.
-        #
-        # Known enforcement strategies are "Strict" and "None".
-        #
-        # When set to "Strict", any changes to the description of a property
-        # is considered incompatible.
-        #
-        # When set to "None", changes to the description of a property are
-        # not considered incompatible.
-        #
-        # If set to an unknown value, the "Strict" enforcement strategy
-        # will be used.
-        changeEnforcement: { Strict || None }
-        # removalEnforcement is the enforcement strategy that should be used
-        # when evaluating if the removal of the description of a property
-        # is considered incompatible.
-        #
-        # Known enforcement strategies are "Strict" and "None".
-        #
-        # When set to "Strict", removal of the description of a property
-        # is considered incompatible.
-        #
-        # When set to "None", removal of the description of a property is
-        # not considered incompatible.
-        #
-        # If set to an unknown value, the "Strict" enforcement strategy
-        # will be used.
-        removalEnforcement: { Strict || None }
-        # additionEnforcement is the enforcement strategy that should be used
-        # when evaluating if the addition of a description for a property
-        # is considered incompatible.
-        #
-        # Known enforcement strategies are "Strict" and "None".
-        #
-        # When set to "Strict", addition of a description for a property
-        # is considered incompatible.
-        #
-        # When set to "None", addition of a description for a property is
-        # not considered incompatible.
-        #
-        # If set to an unknown value, the "Strict" enforcement strategy
-        # will be used.
-        additionEnforcement: { Strict || None }
 ```
 
 ### Maximum, MaxLength, MaxItems, and MaxProperties

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,9 +68,6 @@ var StrictPropertyCheckConfig = PropertyCheckConfig{
 		CheckConfig: CheckConfig{
 			Enabled: true,
 		},
-		ChangeEnforcement:   property.DescriptionValidationChangeEnforcementStrict,
-		RemovalEnforcement:  property.DescriptionValidationRemovalEnforcementStrict,
-		AdditionEnforcement: property.DescriptionValidationAdditionEnforcementStrict,
 	},
 	Required: RequiredCheckConfig{
 		CheckConfig: CheckConfig{
@@ -229,9 +226,6 @@ type DefaultCheckConfig struct {
 
 type DescriptionCheckConfig struct {
 	CheckConfig
-	ChangeEnforcement   property.DescriptionValidationChangeEnforcement   `json:"changeEnforcement"`
-	RemovalEnforcement  property.DescriptionValidationRemovalEnforcement  `json:"removalEnforcement"`
-	AdditionEnforcement property.DescriptionValidationAdditionEnforcement `json:"additionEnforcement"`
 }
 
 type RequiredCheckConfig struct {
@@ -327,11 +321,7 @@ func PropertyValidationsForPropertyCheckConfig(cfg PropertyCheckConfig) []proper
 	}
 
 	if cfg.Description.Enabled {
-		validations = append(validations, &property.Description{
-			ChangeEnforcement:   cfg.Description.ChangeEnforcement,
-			RemovalEnforcement:  cfg.Description.RemovalEnforcement,
-			AdditionEnforcement: cfg.Description.AdditionEnforcement,
-		})
+		validations = append(validations, &property.Description{})
 	}
 
 	if cfg.Required.Enabled {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,6 +64,14 @@ var StrictPropertyCheckConfig = PropertyCheckConfig{
 		RemovalEnforcement:  property.DefaultValidationRemovalEnforcementStrict,
 		AdditionEnforcement: property.DefaultValidationAdditionEnforcementStrict,
 	},
+	Description: DescriptionCheckConfig{
+		CheckConfig: CheckConfig{
+			Enabled: true,
+		},
+		ChangeEnforcement:   property.DescriptionValidationChangeEnforcementStrict,
+		RemovalEnforcement:  property.DescriptionValidationRemovalEnforcementStrict,
+		AdditionEnforcement: property.DescriptionValidationAdditionEnforcementStrict,
+	},
 	Required: RequiredCheckConfig{
 		CheckConfig: CheckConfig{
 			Enabled: true,
@@ -187,18 +195,19 @@ type VersionCheckConfig struct {
 }
 
 type PropertyCheckConfig struct {
-	Enum          EnumCheckConfig     `yaml:"enum"`
-	Default       DefaultCheckConfig  `yaml:"default"`
-	Required      RequiredCheckConfig `yaml:"required"`
-	Type          TypeCheckConfig     `yaml:"type"`
-	Maximum       MaxCheckConfig      `yaml:"maximum"`
-	MaxItems      MaxCheckConfig      `yaml:"maxItems"`
-	MaxProperties MaxCheckConfig      `yaml:"maxProperties"`
-	MaxLength     MaxCheckConfig      `yaml:"maxLength"`
-	Minimum       MinCheckConfig      `yaml:"minimum"`
-	MinItems      MinCheckConfig      `yaml:"minItems"`
-	MinProperties MinCheckConfig      `yaml:"minProperties"`
-	MinLength     MinCheckConfig      `yaml:"minLength"`
+	Enum          EnumCheckConfig        `yaml:"enum"`
+	Default       DefaultCheckConfig     `yaml:"default"`
+	Description   DescriptionCheckConfig `yaml:"description"`
+	Required      RequiredCheckConfig    `yaml:"required"`
+	Type          TypeCheckConfig        `yaml:"type"`
+	Maximum       MaxCheckConfig         `yaml:"maximum"`
+	MaxItems      MaxCheckConfig         `yaml:"maxItems"`
+	MaxProperties MaxCheckConfig         `yaml:"maxProperties"`
+	MaxLength     MaxCheckConfig         `yaml:"maxLength"`
+	Minimum       MinCheckConfig         `yaml:"minimum"`
+	MinItems      MinCheckConfig         `yaml:"minItems"`
+	MinProperties MinCheckConfig         `yaml:"minProperties"`
+	MinLength     MinCheckConfig         `yaml:"minLength"`
 }
 
 type CheckConfig struct {
@@ -216,6 +225,13 @@ type DefaultCheckConfig struct {
 	ChangeEnforcement   property.DefaultValidationChangeEnforcement   `json:"changeEnforcement"`
 	RemovalEnforcement  property.DefaultValidationRemovalEnforcement  `json:"removalEnforcement"`
 	AdditionEnforcement property.DefaultValidationAdditionEnforcement `json:"additionEnforcement"`
+}
+
+type DescriptionCheckConfig struct {
+	CheckConfig
+	ChangeEnforcement   property.DescriptionValidationChangeEnforcement   `json:"changeEnforcement"`
+	RemovalEnforcement  property.DescriptionValidationRemovalEnforcement  `json:"removalEnforcement"`
+	AdditionEnforcement property.DescriptionValidationAdditionEnforcement `json:"additionEnforcement"`
 }
 
 type RequiredCheckConfig struct {
@@ -245,7 +261,7 @@ func ValidatorForConfig(cfg Config) *crd.Validator {
 }
 
 func ValidationsForCRDChecks(checks CRDChecks) []crd.Validation {
-	validations := []crd.Validation{}
+	var validations []crd.Validation
 	if checks.Scope.Enabled {
 		validations = append(validations, &crd.Scope{})
 	}
@@ -294,7 +310,7 @@ func ServedVersionConfigForServedVersionCheckConfig(cfg ServedVersionCheckConfig
 }
 
 func PropertyValidationsForPropertyCheckConfig(cfg PropertyCheckConfig) []property.Validation {
-	validations := []property.Validation{}
+	var validations []property.Validation
 	if cfg.Enum.Enabled {
 		validations = append(validations, &property.Enum{
 			RemovalEnforcement:  cfg.Enum.RemovalEnforcement,
@@ -307,6 +323,14 @@ func PropertyValidationsForPropertyCheckConfig(cfg PropertyCheckConfig) []proper
 			ChangeEnforcement:   cfg.Default.ChangeEnforcement,
 			RemovalEnforcement:  cfg.Default.RemovalEnforcement,
 			AdditionEnforcement: cfg.Default.AdditionEnforcement,
+		})
+	}
+
+	if cfg.Description.Enabled {
+		validations = append(validations, &property.Description{
+			ChangeEnforcement:   cfg.Description.ChangeEnforcement,
+			RemovalEnforcement:  cfg.Description.RemovalEnforcement,
+			AdditionEnforcement: cfg.Description.AdditionEnforcement,
 		})
 	}
 

--- a/pkg/validations/property/description.go
+++ b/pkg/validations/property/description.go
@@ -1,0 +1,106 @@
+package property
+
+import (
+	"fmt"
+)
+
+type DescriptionValidationChangeEnforcement string
+
+const (
+	DescriptionValidationChangeEnforcementStrict = "Strict"
+	DescriptionValidationChangeEnforcementNone   = "None"
+)
+
+type DescriptionValidationRemovalEnforcement string
+
+const (
+	DescriptionValidationRemovalEnforcementStrict = "Strict"
+	DescriptionValidationRemovalEnforcementNone   = "None"
+)
+
+type DescriptionValidationAdditionEnforcement string
+
+const (
+	DescriptionValidationAdditionEnforcementStrict = "Strict"
+	DescriptionValidationAdditionEnforcementNone   = "None"
+)
+
+type Description struct {
+	// ChangeEnforcement is the enforcement strategy that should be used
+	// when evaluating if a change to the description of a property
+	// is considered incompatible.
+	//
+	// Known enforcement strategies are "Strict" and "None".
+	//
+	// When set to "Strict", any changes to the description of a property
+	// is considered incompatible.
+	//
+	// When set to "None", changes to the description of a property are
+	// not considered incompatible.
+	//
+	// If set to an unknown value, the "Strict" enforcement strategy
+	// will be used.
+	ChangeEnforcement DescriptionValidationChangeEnforcement
+
+	// RemovalEnforcement is the enforcement strategy that should be used
+	// when evaluating if the removal of the description of a property
+	// is considered incompatible.
+	//
+	// Known enforcement strategies are "Strict" and "None".
+	//
+	// When set to "Strict", removal of the description of a property
+	// is considered incompatible.
+	//
+	// When set to "None", removal of the description of a property is
+	// not considered incompatible.
+	//
+	// If set to an unknown value, the "Strict" enforcement strategy
+	// will be used.
+	RemovalEnforcement DescriptionValidationRemovalEnforcement
+
+	// AdditionEnforcement is the enforcement strategy that should be used
+	// when evaluating if the addition of a description for a property
+	// is considered incompatible.
+	//
+	// Known enforcement strategies are "Strict" and "None".
+	//
+	// When set to "Strict", addition of a description for a property
+	// is considered incompatible.
+	//
+	// When set to "None", addition of a description for a property is
+	// not considered incompatible.
+	//
+	// If set to an unknown value, the "Strict" enforcement strategy
+	// will be used.
+	AdditionEnforcement DescriptionValidationAdditionEnforcement
+}
+
+func (d *Description) Name() string {
+	return "description"
+}
+
+func (d *Description) Validate(diff Diff) (Diff, bool, error) {
+	reset := func(diff Diff) Diff {
+		oldProperty := diff.Old()
+		newProperty := diff.New()
+		newProperty.Description = ""
+		oldProperty.Description = ""
+		return NewDiff(oldProperty, newProperty)
+	}
+
+	oldDescription := diff.Old().Description
+	newDescription := diff.New().Description
+	var err error
+
+	switch {
+	case oldDescription == "" && newDescription != "" && d.AdditionEnforcement != DescriptionValidationAdditionEnforcementNone:
+		err = fmt.Errorf("description %q added when there was no description previously", newDescription)
+	case oldDescription != "" && newDescription == "" && d.RemovalEnforcement != DescriptionValidationRemovalEnforcementNone:
+		err = fmt.Errorf("description %q removed", oldDescription)
+	case oldDescription != "" && newDescription != "" && oldDescription != newDescription && d.ChangeEnforcement != DescriptionValidationChangeEnforcementNone:
+		err = fmt.Errorf("description changed from %q to %q", oldDescription, newDescription)
+	}
+
+	resetDiff, handled := IsHandled(diff, reset)
+	return resetDiff, handled, err
+}

--- a/pkg/validations/property/description.go
+++ b/pkg/validations/property/description.go
@@ -1,78 +1,6 @@
 package property
 
-import (
-	"fmt"
-)
-
-type DescriptionValidationChangeEnforcement string
-
-const (
-	DescriptionValidationChangeEnforcementStrict = "Strict"
-	DescriptionValidationChangeEnforcementNone   = "None"
-)
-
-type DescriptionValidationRemovalEnforcement string
-
-const (
-	DescriptionValidationRemovalEnforcementStrict = "Strict"
-	DescriptionValidationRemovalEnforcementNone   = "None"
-)
-
-type DescriptionValidationAdditionEnforcement string
-
-const (
-	DescriptionValidationAdditionEnforcementStrict = "Strict"
-	DescriptionValidationAdditionEnforcementNone   = "None"
-)
-
 type Description struct {
-	// ChangeEnforcement is the enforcement strategy that should be used
-	// when evaluating if a change to the description of a property
-	// is considered incompatible.
-	//
-	// Known enforcement strategies are "Strict" and "None".
-	//
-	// When set to "Strict", any changes to the description of a property
-	// is considered incompatible.
-	//
-	// When set to "None", changes to the description of a property are
-	// not considered incompatible.
-	//
-	// If set to an unknown value, the "Strict" enforcement strategy
-	// will be used.
-	ChangeEnforcement DescriptionValidationChangeEnforcement
-
-	// RemovalEnforcement is the enforcement strategy that should be used
-	// when evaluating if the removal of the description of a property
-	// is considered incompatible.
-	//
-	// Known enforcement strategies are "Strict" and "None".
-	//
-	// When set to "Strict", removal of the description of a property
-	// is considered incompatible.
-	//
-	// When set to "None", removal of the description of a property is
-	// not considered incompatible.
-	//
-	// If set to an unknown value, the "Strict" enforcement strategy
-	// will be used.
-	RemovalEnforcement DescriptionValidationRemovalEnforcement
-
-	// AdditionEnforcement is the enforcement strategy that should be used
-	// when evaluating if the addition of a description for a property
-	// is considered incompatible.
-	//
-	// Known enforcement strategies are "Strict" and "None".
-	//
-	// When set to "Strict", addition of a description for a property
-	// is considered incompatible.
-	//
-	// When set to "None", addition of a description for a property is
-	// not considered incompatible.
-	//
-	// If set to an unknown value, the "Strict" enforcement strategy
-	// will be used.
-	AdditionEnforcement DescriptionValidationAdditionEnforcement
 }
 
 func (d *Description) Name() string {
@@ -88,19 +16,6 @@ func (d *Description) Validate(diff Diff) (Diff, bool, error) {
 		return NewDiff(oldProperty, newProperty)
 	}
 
-	oldDescription := diff.Old().Description
-	newDescription := diff.New().Description
-	var err error
-
-	switch {
-	case oldDescription == "" && newDescription != "" && d.AdditionEnforcement != DescriptionValidationAdditionEnforcementNone:
-		err = fmt.Errorf("description %q added when there was no description previously", newDescription)
-	case oldDescription != "" && newDescription == "" && d.RemovalEnforcement != DescriptionValidationRemovalEnforcementNone:
-		err = fmt.Errorf("description %q removed", oldDescription)
-	case oldDescription != "" && newDescription != "" && oldDescription != newDescription && d.ChangeEnforcement != DescriptionValidationChangeEnforcementNone:
-		err = fmt.Errorf("description changed from %q to %q", oldDescription, newDescription)
-	}
-
 	resetDiff, handled := IsHandled(diff, reset)
-	return resetDiff, handled, err
+	return resetDiff, handled, nil
 }

--- a/pkg/validations/property/description_test.go
+++ b/pkg/validations/property/description_test.go
@@ -1,7 +1,6 @@
 package property
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -40,74 +39,36 @@ func TestDescription(t *testing.T) {
 			description: &Description{},
 		},
 		{
-			name:        "new description, error, handled",
+			name:        "new description, no error, handled",
 			oldProperty: &apiextensionsv1.JSONSchemaProps{},
 			newProperty: &apiextensionsv1.JSONSchemaProps{
 				Description: "new foo",
 			},
-			err:         errors.New("description \"new foo\" added when there was no description previously"),
+			err:         nil,
 			handled:     true,
 			description: &Description{},
 		},
 		{
-			name:        "new description, addition enforcement set to None, no error, handled",
-			oldProperty: &apiextensionsv1.JSONSchemaProps{},
-			newProperty: &apiextensionsv1.JSONSchemaProps{
-				Description: "new foo",
-			},
-			err:     nil,
-			handled: true,
-			description: &Description{
-				AdditionEnforcement: DescriptionValidationAdditionEnforcementNone,
-			},
-		},
-		{
-			name: "description removed, error, handled",
-			oldProperty: &apiextensionsv1.JSONSchemaProps{
-				Description: "old foo",
-			},
-			newProperty: &apiextensionsv1.JSONSchemaProps{},
-			err:         errors.New("description \"old foo\" removed"),
-			handled:     true,
-			description: &Description{},
-		},
-		{
-			name: "description removed, removal enforcement set to None, no error, handled",
+			name: "description removed, no error, handled",
 			oldProperty: &apiextensionsv1.JSONSchemaProps{
 				Description: "old foo",
 			},
 			newProperty: &apiextensionsv1.JSONSchemaProps{},
 			err:         nil,
 			handled:     true,
-			description: &Description{
-				RemovalEnforcement: DescriptionValidationRemovalEnforcementNone,
-			},
-		},
-		{
-			name: "description changed, error, handled",
-			oldProperty: &apiextensionsv1.JSONSchemaProps{
-				Description: "old foo",
-			},
-			newProperty: &apiextensionsv1.JSONSchemaProps{
-				Description: "new foo",
-			},
-			err:         errors.New("description changed from \"old foo\" to \"new foo\""),
-			handled:     true,
 			description: &Description{},
 		},
 		{
-			name: "description changed, change enforcement set to None, no error, handled",
+			name: "description changed, no error, handled",
 			oldProperty: &apiextensionsv1.JSONSchemaProps{
 				Description: "old foo",
 			},
 			newProperty: &apiextensionsv1.JSONSchemaProps{
 				Description: "new foo",
 			},
-			err:     nil,
-			handled: true,
-			description: &Description{
-				ChangeEnforcement: DescriptionValidationChangeEnforcementNone,
-			},
+			err:         nil,
+			handled:     true,
+			description: &Description{},
 		},
 		{
 			name: "different field changed, no error, not handled",

--- a/pkg/validations/property/description_test.go
+++ b/pkg/validations/property/description_test.go
@@ -1,0 +1,131 @@
+package property
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestDescription(t *testing.T) {
+	type testcase struct {
+		name        string
+		oldProperty *apiextensionsv1.JSONSchemaProps
+		newProperty *apiextensionsv1.JSONSchemaProps
+		err         error
+		handled     bool
+		description *Description
+	}
+
+	for _, tc := range []testcase{
+		{
+			name:        "no description, no error, handled",
+			oldProperty: &apiextensionsv1.JSONSchemaProps{},
+			newProperty: &apiextensionsv1.JSONSchemaProps{},
+			err:         nil,
+			handled:     true,
+			description: &Description{},
+		},
+		{
+			name: "no diff, no error, handled",
+			oldProperty: &apiextensionsv1.JSONSchemaProps{
+				Description: "foo",
+			},
+			newProperty: &apiextensionsv1.JSONSchemaProps{
+				Description: "foo",
+			},
+			err:         nil,
+			handled:     true,
+			description: &Description{},
+		},
+		{
+			name:        "new description, error, handled",
+			oldProperty: &apiextensionsv1.JSONSchemaProps{},
+			newProperty: &apiextensionsv1.JSONSchemaProps{
+				Description: "new foo",
+			},
+			err:         errors.New("description \"new foo\" added when there was no description previously"),
+			handled:     true,
+			description: &Description{},
+		},
+		{
+			name:        "new description, addition enforcement set to None, no error, handled",
+			oldProperty: &apiextensionsv1.JSONSchemaProps{},
+			newProperty: &apiextensionsv1.JSONSchemaProps{
+				Description: "new foo",
+			},
+			err:     nil,
+			handled: true,
+			description: &Description{
+				AdditionEnforcement: DescriptionValidationAdditionEnforcementNone,
+			},
+		},
+		{
+			name: "description removed, error, handled",
+			oldProperty: &apiextensionsv1.JSONSchemaProps{
+				Description: "old foo",
+			},
+			newProperty: &apiextensionsv1.JSONSchemaProps{},
+			err:         errors.New("description \"old foo\" removed"),
+			handled:     true,
+			description: &Description{},
+		},
+		{
+			name: "description removed, removal enforcement set to None, no error, handled",
+			oldProperty: &apiextensionsv1.JSONSchemaProps{
+				Description: "old foo",
+			},
+			newProperty: &apiextensionsv1.JSONSchemaProps{},
+			err:         nil,
+			handled:     true,
+			description: &Description{
+				RemovalEnforcement: DescriptionValidationRemovalEnforcementNone,
+			},
+		},
+		{
+			name: "description changed, error, handled",
+			oldProperty: &apiextensionsv1.JSONSchemaProps{
+				Description: "old foo",
+			},
+			newProperty: &apiextensionsv1.JSONSchemaProps{
+				Description: "new foo",
+			},
+			err:         errors.New("description changed from \"old foo\" to \"new foo\""),
+			handled:     true,
+			description: &Description{},
+		},
+		{
+			name: "description changed, change enforcement set to None, no error, handled",
+			oldProperty: &apiextensionsv1.JSONSchemaProps{
+				Description: "old foo",
+			},
+			newProperty: &apiextensionsv1.JSONSchemaProps{
+				Description: "new foo",
+			},
+			err:     nil,
+			handled: true,
+			description: &Description{
+				ChangeEnforcement: DescriptionValidationChangeEnforcementNone,
+			},
+		},
+		{
+			name: "different field changed, no error, not handled",
+			oldProperty: &apiextensionsv1.JSONSchemaProps{
+				ID: "foo",
+			},
+			newProperty: &apiextensionsv1.JSONSchemaProps{
+				ID: "bar",
+			},
+			err:         nil,
+			handled:     false,
+			description: &Description{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, handled, err := tc.description.Validate(NewDiff(tc.oldProperty, tc.newProperty))
+			require.Equal(t, tc.err, err)
+			require.Equal(t, tc.handled, handled)
+		})
+	}
+}


### PR DESCRIPTION
Currently, validation fails if the description of a property is changed in any way. The description validator ensures that it is possible to change the description of a property without failing validation.