### PR TITLE
validations: Add new property validation for 'anyOf'

### DIFF
--- a/docs/validations.md
+++ b/docs/validations.md
@@ -124,3 +124,8 @@ Validates compatibility of changes to a property description. While most changes
 description of a property are _generally_ safe, it is important to note that changing
 the semantics of a field _is_ a breaking change as it breaks expectations clients/users
 have made about what configuring the property does.
+
+### anyOf
+Validates compatibility of changes to the anyOf property. Changing the anyOf property 
+in a way that alters the set of valid values for a property is considered a breaking 
+change, as it may impact client and user expectations about accepted input.

--- a/pkg/runner/registry.go
+++ b/pkg/runner/registry.go
@@ -29,6 +29,7 @@ func init() {
 	existingfieldremoval.Register(defaultRegistry)
 	scope.Register(defaultRegistry)
 	storedversionremoval.Register(defaultRegistry)
+	property.RegisterAnyOf(defaultRegistry)
 	property.RegisterDefault(defaultRegistry)
 	property.RegisterEnum(defaultRegistry)
 	property.RegisterMaximum(defaultRegistry)

--- a/pkg/validations/property/anyof.go
+++ b/pkg/validations/property/anyof.go
@@ -1,0 +1,175 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+const anyOfValidationName = "anyOf"
+
+var (
+	_ validations.Validation                                  = (*Enum)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*Enum)(nil)
+	// ErrNilAnyOfConfig is returned when the AnyOfConfig is nil.
+	ErrNilAnyOfConfig = errors.New("AnyOfConfig must not be nil")
+	// ErrAtLeastOneSubschema is returned when an unknown AdditionPolicy is provided.
+	ErrAtLeastOneSubschema = errors.New("AnyOfConfig must contain at least one subschema")
+)
+
+// RegisterAnyOf registers the AnyOf validation
+// with the provided validation registry.
+func RegisterAnyOf(registry validations.Registry) {
+	registry.Register(anyOfValidationName, anyOfFactory)
+}
+
+// anyOfFactory is a function used to initialize an Enum validation
+// implementation based on the provided configuration.
+func anyOfFactory(cfg map[string]interface{}) (validations.Validation, error) {
+	anyOfCfg := &AnyOfConfig{}
+
+	err := ConfigToType(cfg, anyOfCfg)
+	if err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	err = ValidateAnyOfConfig(anyOfCfg)
+	if err != nil {
+		return nil, fmt.Errorf("validating anyOf config: %w", err)
+	}
+
+	return &AnyOf{AnyOfConfig: *anyOfCfg}, nil
+}
+
+// ValidateAnyOfConfig validates the provided AnyOfConfig
+// setting default values where appropriate.
+// Currently the defaulting behavior defaults the
+// AnyOfConfig.AdditionPolicy to AdditionPolicyDisallow
+// if it is set to the empty string ("").
+func ValidateAnyOfConfig(in *AnyOfConfig) error {
+	if in == nil {
+		return fmt.Errorf("%w", ErrNilAnyOfConfig)
+	}
+
+	if len(in.Subschemas) == 0 {
+		return fmt.Errorf("%w", ErrAtLeastOneSubschema)
+	}
+
+	switch in.AdditionPolicy {
+	case AdditionPolicyAllow, AdditionPolicyDisallow:
+		// valid
+	case AdditionPolicy(""):
+		// default to disallow
+		in.AdditionPolicy = AdditionPolicyDisallow
+	default:
+		return fmt.Errorf("%w: %q", errUnknownAdditionPolicy, in.AdditionPolicy)
+	}
+
+	return nil
+}
+
+// AnyOfConfig contains additional configurations for the AnyOf validation.
+type AnyOfConfig struct {
+	// additionPolicy is how adding enums to an existing set of
+	// enums should be treated.
+	// Allowed values are Allow and Disallow.
+	// When set to Allow, adding new values to an existing set
+	// of enums will not be flagged.
+	// When set to Disallow, adding new values to an existing
+	// set of enums will be flagged.
+	// Defaults to Disallow.
+	AdditionPolicy AdditionPolicy `json:"additionPolicy,omitempty"`
+	// Subschemas is a list of subschemas that are part of the anyOf constraint.
+	Subschemas []apiextensionsv1.JSONSchemaProps `json:"subschemas,omitempty"`
+}
+
+// AnyOf is a validation implementation for the "anyOf" constraint in JSONSchemaProps.
+type AnyOf struct {
+	// AnyOfConfig is the set of additional configuration options
+	AnyOfConfig
+	enforcement config.EnforcementPolicy
+}
+
+// Name NewAnyOf creates a new AnyOf validation instance with the provided configuration.
+func (a *AnyOf) Name() string {
+	return anyOfValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the Required validation.
+func (a *AnyOf) SetEnforcement(policy config.EnforcementPolicy) {
+	a.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the format constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.format field will be reset to '""' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (a *AnyOf) Compare(old, newProp *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	oldList := old.AnyOf
+	newList := newProp.AnyOf
+
+	var err error
+
+	switch {
+	case len(oldList) == 0 && len(newList) > 0:
+		err = fmt.Errorf("%w : net-new anyOf constraint added", ErrNetNewAnyOfConstraint)
+	case len(oldList) > 0 && len(newList) == 0:
+		err = fmt.Errorf("%w : anyOf constraint removed", ErrRemovedAnyOfConstraint)
+	case !anyOfEqual(oldList, newList):
+		err = fmt.Errorf("%w : anyOf subschemas changed", ErrChangedAnyOfConstraint)
+	}
+
+	old.AnyOf = nil
+	newProp.AnyOf = nil
+
+	return validations.HandleErrors(a.Name(), a.enforcement, err)
+}
+
+// anyOfEqual compares two slices of JSONSchemaProps for deep equality.
+func anyOfEqual(a, b []apiextensionsv1.JSONSchemaProps) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if !equalJSONSchemaProps(&a[i], &b[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// equalJSONSchemaProps performs a deep comparison of two JSONSchemaProps.
+// Replace with a proper deep equality check as needed.
+func equalJSONSchemaProps(a, b *apiextensionsv1.JSONSchemaProps) bool {
+	return reflect.DeepEqual(a, b)
+}
+
+var (
+	// ErrNetNewAnyOfConstraint represents an error state where a net new anyOf constraint was added to a property.
+	ErrNetNewAnyOfConstraint = errors.New("anyOf constraint added when there was none previously")
+	// ErrRemovedAnyOfConstraint represents an error state where the anyOf constraint was removed from a property.
+	ErrRemovedAnyOfConstraint = errors.New("anyOf constraint removed")
+	// ErrChangedAnyOfConstraint represents an error state where the anyOf subschemas changed.
+	ErrChangedAnyOfConstraint = errors.New("anyOf subschemas changed")
+)

--- a/pkg/validations/property/anyof_test.go
+++ b/pkg/validations/property/anyof_test.go
@@ -1,0 +1,100 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestAnyOf(t *testing.T) {
+	{
+		tests := []struct {
+			name    string
+			in      *AnyOfConfig
+			wantErr bool
+		}{
+			{
+				name:    "nil config",
+				in:      nil,
+				wantErr: true,
+			},
+			{
+				name: "empty subschemas",
+				in: &AnyOfConfig{
+					AdditionPolicy: AdditionPolicyAllow,
+					Subschemas:     nil,
+				},
+				wantErr: true,
+			},
+			{
+				name: "valid config with allow",
+				in: &AnyOfConfig{
+					AdditionPolicy: AdditionPolicyAllow,
+					Subschemas: []apiextensionsv1.JSONSchemaProps{
+						{},
+					},
+				},
+				wantErr: false,
+			},
+			{
+				name: "valid config with disallow",
+				in: &AnyOfConfig{
+					AdditionPolicy: AdditionPolicyDisallow,
+					Subschemas: []apiextensionsv1.JSONSchemaProps{
+						{},
+					},
+				},
+				wantErr: false,
+			},
+			{
+				name: "invalid addition policy",
+				in: &AnyOfConfig{
+					AdditionPolicy: "invalid",
+					Subschemas: []apiextensionsv1.JSONSchemaProps{
+						{},
+					},
+				},
+				wantErr: true,
+			},
+			{
+				name: "empty addition policy defaults to disallow",
+				in: &AnyOfConfig{
+					AdditionPolicy: "",
+					Subschemas: []apiextensionsv1.JSONSchemaProps{
+						{},
+					},
+				},
+				wantErr: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				err := ValidateAnyOfConfig(tt.in)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("ValidateAnyOfConfig() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				// Check defaulting behavior
+				if tt.in != nil && tt.in.AdditionPolicy == "" && !tt.wantErr {
+					if tt.in.AdditionPolicy != AdditionPolicyDisallow {
+						t.Errorf("AdditionPolicy not defaulted to Disallow, got %q", tt.in.AdditionPolicy)
+					}
+				}
+			})
+		}
+	}
+}

--- a/test/anyofvalueadded/a.yaml
+++ b/test/anyofvalueadded/a.yaml
@@ -1,0 +1,142 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: memcacheds.cache.example.com
+spec:
+  group: cache.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Memcached is the Schema for the memcacheds API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MemcachedSpec defines the desired state of Memcached
+              properties:
+                containerPort:
+                  description: Port defines the port that will be used to init the container
+                    with the image
+                  format: int32
+                  type: integer
+                size:
+                  description: Size defines the number of Memcached instances
+                  format: int32
+                  maximum: 3
+                  minimum: 1
+                  type: integer
+                mode:
+                  description: Mode in which the Memcached instances should be handled
+                  type: string
+                  enum:
+                    - "Managed"
+                    - "Unmanaged"
+                  default: "Managed"
+              type: object
+              required:
+                - size
+            status:
+              description: MemcachedStatus defines the observed state of Memcached
+              properties:
+                conditions:
+                  description: Conditions store the status conditions of the Memcached
+                    instances
+                  items:
+                    description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/test/anyofvalueadded/b.yaml
+++ b/test/anyofvalueadded/b.yaml
@@ -1,0 +1,141 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: memcacheds.cache.example.com
+spec:
+  group: cache.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Memcached is the Schema for the memcacheds API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MemcachedSpec defines the desired state of Memcached
+              properties:
+                containerPort:
+                  description: Port defines the port that will be used to init the container
+                    with the image
+                  format: int32
+                  type: integer
+                size:
+                  description: Size defines the number of Memcached instances
+                  format: int32
+                  maximum: 3
+                  minimum: 1
+                  type: integer
+                mode:
+                  description: Mode in which the Memcached instances should be handled
+                  type: string
+                  enum:
+                    - Managed
+                    - Unmanaged
+              type: object
+              required:
+                - size
+            status:
+              description: MemcachedStatus defines the observed state of Memcached
+              properties:
+                conditions:
+                  description: Conditions store the status conditions of the Memcached
+                    instances
+                  items:
+                    description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/test/anyofvalueadded/expected.json
+++ b/test/anyofvalueadded/expected.json
@@ -1,0 +1,67 @@
+{
+  "crdValidation": [
+    {
+      "name": "scope"
+    },
+    {
+      "name": "storedVersionRemoval"
+    },
+    {
+      "name": "existingFieldRemoval"
+    }
+  ],
+  "sameVersionValidation": {
+    "v1alpha1": {
+      "^.spec.mode": [
+        {
+          "name": "minProperties"
+        },
+        {
+          "name": "maximum"
+        },
+        {
+          "name": "anyOf",
+          "errors": [
+            "allowed anyOf values added : [\"Unmanaged\"]"
+          ]
+        },
+        {
+          "name": "enum"
+        },
+        {
+          "name": "maxLength"
+        },
+        {
+          "name": "maxProperties"
+        },
+        {
+          "name": "minimum"
+        },
+        {
+          "name": "required"
+        },
+        {
+          "name": "default"
+        },
+        {
+          "name": "minItems"
+        },
+        {
+          "name": "minLength"
+        },
+        {
+          "name": "maxItems"
+        },
+        {
+          "name": "type"
+        },
+        {
+          "name": "description"
+        },
+        {
+          "name": "unhandled"
+        }
+      ]
+    }
+  }
+}

--- a/test/anyofvaluenetnew/a.yaml
+++ b/test/anyofvaluenetnew/a.yaml
@@ -1,0 +1,141 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: memcacheds.cache.example.com
+spec:
+  group: cache.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Memcached is the Schema for the memcacheds API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MemcachedSpec defines the desired state of Memcached
+              properties:
+                containerPort:
+                  description: Port defines the port that will be used to init the container
+                    with the image
+                  format: int32
+                  type: integer
+                size:
+                  description: Size defines the number of Memcached instances
+                  format: int32
+                  maximum: 3
+                  minimum: 1
+                  type: integer
+                mode:
+                  description: Mode in which the Memcached instances should be handled
+                  anyOf:
+                    - type: string
+                      enum: ["Managed"]
+                    - type: integer
+              type: object
+              required:
+                - size
+            status:
+              description: MemcachedStatus defines the observed state of Memcached
+              properties:
+                conditions:
+                  description: Conditions store the status conditions of the Memcached
+                    instances
+                  items:
+                    description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/test/anyofvaluenetnew/b.yaml
+++ b/test/anyofvaluenetnew/b.yaml
@@ -1,0 +1,142 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: memcacheds.cache.example.com
+spec:
+  group: cache.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Memcached is the Schema for the memcacheds API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MemcachedSpec defines the desired state of Memcached
+              properties:
+                containerPort:
+                  description: Port defines the port that will be used to init the container
+                    with the image
+                  format: int32
+                  type: integer
+                size:
+                  description: Size defines the number of Memcached instances
+                  format: int32
+                  maximum: 3
+                  minimum: 1
+                  type: integer
+                mode:
+                  description: Mode in which the Memcached instances should be handled
+                  anyOf:
+                    - type: string
+                      enum: ["Managed"]
+                    - type: integer
+                  default: "Managed"
+              type: object
+              required:
+                - size
+            status:
+              description: MemcachedStatus defines the observed state of Memcached
+              properties:
+                conditions:
+                  description: Conditions store the status conditions of the Memcached
+                    instances
+                  items:
+                    description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/test/anyofvaluenetnew/expected.json
+++ b/test/anyofvaluenetnew/expected.json
@@ -1,0 +1,67 @@
+{
+  "crdValidation": [
+    {
+      "name": "existingFieldRemoval"
+    },
+    {
+      "name": "scope"
+    },
+    {
+      "name": "storedVersionRemoval"
+    }
+  ],
+  "sameVersionValidation": {
+    "v1alpha1": {
+      "^.spec.mode": [
+        {
+          "name": "type"
+        },
+        {
+          "name": "minProperties"
+        },
+        {
+          "name": "description"
+        },
+        {
+          "name": "anyOf",
+          "errors": [
+            "anyOf constraint added when there was none previously : [\"\" \"Managed\" \"Unmanaged\"]"
+          ]
+        },
+        {
+          "name": "enum"
+        },
+        {
+          "name": "maxLength"
+        },
+        {
+          "name": "minimum"
+        },
+        {
+          "name": "maximum"
+        },
+        {
+          "name": "default"
+        },
+        {
+          "name": "minItems"
+        },
+        {
+          "name": "maxProperties"
+        },
+        {
+          "name": "minLength"
+        },
+        {
+          "name": "maxItems"
+        },
+        {
+          "name": "required"
+        },
+        {
+          "name": "unhandled"
+        }
+      ]
+    }
+  }
+}

--- a/test/anyofvalueremoved/a.yaml
+++ b/test/anyofvalueremoved/a.yaml
@@ -1,0 +1,142 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: memcacheds.cache.example.com
+spec:
+  group: cache.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Memcached is the Schema for the memcacheds API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MemcachedSpec defines the desired state of Memcached
+              properties:
+                containerPort:
+                  description: Port defines the port that will be used to init the container
+                    with the image
+                  format: int32
+                  type: integer
+                size:
+                  description: Size defines the number of Memcached instances
+                  format: int32
+                  maximum: 3
+                  minimum: 1
+                  type: integer
+                mode:
+                  description: Mode in which the Memcached instances should be handled
+                  type: string
+                  enum:
+                  - "Managed"
+                  - "Unmanaged"
+                  default: "Managed"
+              type: object
+              required:
+                - size
+            status:
+              description: MemcachedStatus defines the observed state of Memcached
+              properties:
+                conditions:
+                  description: Conditions store the status conditions of the Memcached
+                    instances
+                  items:
+                    description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/test/anyofvalueremoved/b.yaml
+++ b/test/anyofvalueremoved/b.yaml
@@ -1,0 +1,140 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: memcacheds.cache.example.com
+spec:
+  group: cache.example.com
+  names:
+    kind: Memcached
+    listKind: MemcachedList
+    plural: memcacheds
+    singular: memcached
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Memcached is the Schema for the memcacheds API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MemcachedSpec defines the desired state of Memcached
+              properties:
+                containerPort:
+                  description: Port defines the port that will be used to init the container
+                    with the image
+                  format: int32
+                  type: integer
+                size:
+                  description: Size defines the number of Memcached instances
+                  format: int32
+                  maximum: 3
+                  minimum: 1
+                  type: integer
+                mode:
+                  description: Mode in which the Memcached instances should be handled
+                  type: string
+                  enum:
+                    - Managed
+              type: object
+              required:
+                - size
+            status:
+              description: MemcachedStatus defines the observed state of Memcached
+              properties:
+                conditions:
+                  description: Conditions store the status conditions of the Memcached
+                    instances
+                  items:
+                    description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/test/anyofvalueremoved/expected.json
+++ b/test/anyofvalueremoved/expected.json
@@ -1,0 +1,67 @@
+{
+  "crdValidation": [
+    {
+      "name": "storedVersionRemoval"
+    },
+    {
+      "name": "existingFieldRemoval"
+    },
+    {
+      "name": "scope"
+    }
+  ],
+  "sameVersionValidation": {
+    "v1alpha1": {
+      "^.spec.mode": [
+        {
+          "name": "maxLength"
+        },
+        {
+          "name": "maxItems"
+        },
+        {
+          "name": "minimum"
+        },
+        {
+          "name": "minItems"
+        },
+        {
+          "name": "description"
+        },
+        {
+          "name": "required"
+        },
+        {
+          "name": "maxProperties"
+        },
+        {
+          "name": "minLength"
+        },
+        {
+          "name": "minProperties"
+        },
+        {
+          "name": "type"
+        },
+        {
+          "name": "default"
+        },
+        {
+          "name": "anyOf",
+          "errors": [
+            "allowed anyOf values removed : [\"Unmanaged\"]"
+          ]
+        },
+        {
+          "name": "enum"
+        },
+        {
+          "name": "maximum"
+        },
+        {
+          "name": "unhandled"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new property validation for validating compatibility of changes to the anyOf constraint of a CRD schema property.

Addresses issue #26 