### PR TITLE
validations: update FlattenCRDVersion to key on actual field path instead of simple location

### DIFF
--- a/pkg/validations/util.go
+++ b/pkg/validations/util.go
@@ -50,8 +50,8 @@ func FlattenCRDVersion(crdVersion apiextensionsv1.CustomResourceDefinitionVersio
 		field.NewPath("^"),
 		field.NewPath("^"),
 		nil,
-		func(s *apiextensionsv1.JSONSchemaProps, _, simpleLocation *field.Path, _ []*apiextensionsv1.JSONSchemaProps) bool {
-			flatMap[simpleLocation.String()] = s.DeepCopy()
+		func(s *apiextensionsv1.JSONSchemaProps, fldPath, _ *field.Path, _ []*apiextensionsv1.JSONSchemaProps) bool {
+			flatMap[fldPath.String()] = s.DeepCopy()
 			return false
 		},
 	)


### PR DESCRIPTION
This PR fixes a bug found by @joelanford with a proposed fix in #36 .

This PR supersedes #36 based on an offline discussion we had that it would be better to fix the keying logic than remove the extraction and comparison of the `allOf`, `anyOf`, etc. type schema-based constraints.
This is so that we are giving at least _some_ signal on a change in these nested schemas instead of none, even if this might result in a bit of noise.

We discussed that a follow-up improvement in user experience to create an "ignorelist" of changes to not fail on may be reasonable to help combat some potential noise.