### PR TITLE
Add validation for exclusiveMinimum

### DIFF
--- a/pkg/validations/property/min_test.go
+++ b/pkg/validations/property/min_test.go
@@ -77,6 +77,57 @@ func TestMinimum(t *testing.T) {
 			Flagged:              false,
 			ComparableValidation: &Minimum{},
 		},
+		{
+			Name: "exclusiveMinimum changed from false to true, flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				Minimum:          ptr.To(10.0),
+				ExclusiveMinimum: false,
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				Minimum:          ptr.To(10.0),
+				ExclusiveMinimum: true,
+			},
+			Flagged:              true,
+			ComparableValidation: &Minimum{},
+		},
+		{
+			Name: "exclusiveMinimum changed from true to false, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				Minimum:          ptr.To(10.0),
+				ExclusiveMinimum: true,
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				Minimum:          ptr.To(10.0),
+				ExclusiveMinimum: false,
+			},
+			Flagged:              false,
+			ComparableValidation: &Minimum{},
+		},
+		{
+			Name: "net new exclusiveMinimum, flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				Minimum: ptr.To(10.0),
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				Minimum:          ptr.To(10.0),
+				ExclusiveMinimum: true,
+			},
+			Flagged:              true,
+			ComparableValidation: &Minimum{},
+		},
+		{
+			Name: "no diff exclusiveMinimum, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				Minimum:          ptr.To(10.0),
+				ExclusiveMinimum: true,
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				Minimum:          ptr.To(10.0),
+				ExclusiveMinimum: true,
+			},
+			Flagged:              false,
+			ComparableValidation: &Minimum{},
+		},
 	}
 
 	internaltesting.RunTestcases(t, testcases...)


### PR DESCRIPTION
PR to add functionality requested in #20 

In addition to existing checks, makes adding `exclusiveMinimum: true` to a minimum clause a breaking change