### PR TITLE
Update README to include pronunciation of 'crdify'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # crdify
-`crdify` is a CLI tool for comparing Kubernetes `CustomResourceDefinition` resources (CRDs) for differences.
+`crdify` (sur·duh·fai) is a CLI tool for comparing Kubernetes `CustomResourceDefinition` resources (CRDs) for differences.
 It checks for incompatible changes to help:
 - Cluster administrators protect CRDs on their clusters from breaking changes
 - GitOps practitioners prevent CRDs with breaking changes being committed


### PR DESCRIPTION
It became clear that folks were not understanding how we meant this project name to be pronounced. It's almost like "certify" but with a d in the middle.

According to google, certify is `sur·tuh·fai` so I figure `sur·duh·fai` represents the intended pronounciation of the project name.