### PR TITLE
🐛 fix: Fix false "unhandled changes" error when CRD upgrades add optional fields

### DIFF
--- a/pkg/validations/util.go
+++ b/pkg/validations/util.go
@@ -105,11 +105,23 @@ func FlattenedCRDVersionDiff(a, b map[string]*apiextensionsv1.JSONSchemaProps) m
 // differences between a before and after of a given schema
 // without the changes to its children schemas influencing the
 // diff calculation.
+// Every field that SchemaHas recursively walks must be nil'd here so
+// that child-level changes are evaluated only at their own flattened
+// paths and never bubble up as "unhandled" diffs at the parent level.
 // Returns a copy of the provided apiextensionsv1.JSONSchemaProps with children schemas dropped.
 func DropChildrenPropertiesFromJSONSchema(schema *apiextensionsv1.JSONSchemaProps) *apiextensionsv1.JSONSchemaProps {
 	schemaCopy := schema.DeepCopy()
 	schemaCopy.Properties = nil
 	schemaCopy.Items = nil
+	schemaCopy.AllOf = nil
+	schemaCopy.AnyOf = nil
+	schemaCopy.OneOf = nil
+	schemaCopy.Not = nil
+	schemaCopy.AdditionalProperties = nil
+	schemaCopy.PatternProperties = nil
+	schemaCopy.AdditionalItems = nil
+	schemaCopy.Definitions = nil
+	schemaCopy.Dependencies = nil
 
 	return schemaCopy
 }

--- a/pkg/validations/util_test.go
+++ b/pkg/validations/util_test.go
@@ -177,6 +177,133 @@ func TestFlattenedCRDVersionDiff(t *testing.T) {
 	}
 }
 
+func TestDropChildrenPropertiesFromJSONSchema(t *testing.T) {
+	schema := &apiextensionsv1.JSONSchemaProps{
+		Type:        "object",
+		Description: "top level",
+		Required:    []string{"foo"},
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"foo": {Type: "string"},
+		},
+		Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+			Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
+		},
+		AllOf: []apiextensionsv1.JSONSchemaProps{{Type: "object"}},
+		AnyOf: []apiextensionsv1.JSONSchemaProps{{Type: "string"}},
+		OneOf: []apiextensionsv1.JSONSchemaProps{{Type: "integer"}},
+		Not:   &apiextensionsv1.JSONSchemaProps{Type: "boolean"},
+		AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{
+			Allows: true,
+			Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
+		},
+		PatternProperties: map[string]apiextensionsv1.JSONSchemaProps{
+			"^x-": {Type: "string"},
+		},
+		AdditionalItems: &apiextensionsv1.JSONSchemaPropsOrBool{
+			Allows: true,
+			Schema: &apiextensionsv1.JSONSchemaProps{Type: "string"},
+		},
+		Definitions: apiextensionsv1.JSONSchemaDefinitions{
+			"thing": {Type: "object"},
+		},
+		Dependencies: apiextensionsv1.JSONSchemaDependencies{
+			"dep": {Schema: &apiextensionsv1.JSONSchemaProps{Type: "object"}},
+		},
+	}
+
+	result := DropChildrenPropertiesFromJSONSchema(schema)
+
+	require.Equal(t, "object", result.Type, "leaf field Type must be preserved")
+	require.Equal(t, "top level", result.Description, "leaf field Description must be preserved")
+	require.Equal(t, []string{"foo"}, result.Required, "leaf field Required must be preserved")
+
+	require.Nil(t, result.Properties, "Properties must be nil")
+	require.Nil(t, result.Items, "Items must be nil")
+	require.Nil(t, result.AllOf, "AllOf must be nil")
+	require.Nil(t, result.AnyOf, "AnyOf must be nil")
+	require.Nil(t, result.OneOf, "OneOf must be nil")
+	require.Nil(t, result.Not, "Not must be nil")
+	require.Nil(t, result.AdditionalProperties, "AdditionalProperties must be nil")
+	require.Nil(t, result.PatternProperties, "PatternProperties must be nil")
+	require.Nil(t, result.AdditionalItems, "AdditionalItems must be nil")
+	require.Nil(t, result.Definitions, "Definitions must be nil")
+	require.Nil(t, result.Dependencies, "Dependencies must be nil")
+
+	// Original must be unmodified.
+	require.NotNil(t, schema.Properties, "original Properties must not be nil")
+	require.NotNil(t, schema.Items, "original Items must not be nil")
+	require.NotNil(t, schema.AllOf, "original AllOf must not be nil")
+}
+
+func TestFlattenedCRDVersionDiff_AddOptionalField(t *testing.T) {
+	old := apiextensionsv1.CustomResourceDefinitionVersion{
+		Name:    "v1alpha1",
+		Served:  true,
+		Storage: true,
+		Schema: &apiextensionsv1.CustomResourceValidation{
+			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"spec": {
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"secrets": {
+								Type: "array",
+								Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+									Schema: &apiextensionsv1.JSONSchemaProps{
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"key":  {Type: "string", Description: "Key in the object"},
+											"name": {Type: "string", Description: "Name of the object"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	updated := apiextensionsv1.CustomResourceDefinitionVersion{
+		Name:    "v1alpha1",
+		Served:  true,
+		Storage: true,
+		Schema: &apiextensionsv1.CustomResourceValidation{
+			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"spec": {
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"secrets": {
+								Type: "array",
+								Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+									Schema: &apiextensionsv1.JSONSchemaProps{
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"key":       {Type: "string", Description: "Key in the object"},
+											"name":      {Type: "string", Description: "Name of the object"},
+											"mountPath": {Type: "string", Description: "Path to mount the Object"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	oldFlattened := FlattenCRDVersion(old)
+	newFlattened := FlattenCRDVersion(updated)
+	diffs := FlattenedCRDVersionDiff(oldFlattened, newFlattened)
+
+	require.Len(t, diffs, 0, "adding a new optional field must not produce any diff")
+}
+
 func TestFlattenCRDVersion(t *testing.T) {
 	type testcase struct {
 		name         string

--- a/pkg/validators/version/served/served_test.go
+++ b/pkg/validators/version/served/served_test.go
@@ -429,6 +429,116 @@ func TestValidator_Validate_SubtractExistingIssues(t *testing.T) {
 	}
 }
 
+func TestValidator_Validate_AddOptionalFieldAndDescriptionChange(t *testing.T) {
+	// Reproduces the scenario from the RHDH operator upgrade bug where:
+	//   - v1alpha1 has {key, name} in an array items schema
+	//   - v1alpha3 adds an optional "mountPath" field and changes a description
+	// These are non-breaking, additive changes that must NOT be rejected.
+	descriptionComparator := &property.Description{}
+	descriptionComparator.SetEnforcement(config.EnforcementPolicyNone)
+
+	typeComparator := &property.Type{}
+	typeComparator.SetEnforcement(config.EnforcementPolicyError)
+
+	requiredComparator := &property.Required{}
+	requiredComparator.SetEnforcement(config.EnforcementPolicyError)
+
+	v1alpha1Schema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"spec": {
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"extraFiles": {
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"secrets": {
+								Type: "array",
+								Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+									Schema: &apiextensionsv1.JSONSchemaProps{
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"key": {Type: "string", Description: "Key in the object"},
+											"name": {
+												Type:        "string",
+												Description: "Name of the object\nWe support only ConfigMaps and Secrets.",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v1alpha3Schema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"spec": {
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"extraFiles": {
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"secrets": {
+								Type: "array",
+								Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+									Schema: &apiextensionsv1.JSONSchemaProps{
+										Type: "object",
+										Properties: map[string]apiextensionsv1.JSONSchemaProps{
+											"key": {Type: "string", Description: "Key in the object"},
+											"name": {
+												Type:        "string",
+												Description: "Name of the object\nSupported ConfigMaps and Secrets",
+											},
+											"mountPath": {
+												Type:        "string",
+												Description: "Path to mount the Object. If not specified default-path/Name will be used",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Old CRD: both versions serve identical schemas (no cross-version diff).
+	oldCRD := createCRD(
+		withVersion("v1alpha1", true, v1alpha1Schema.DeepCopy()),
+		withVersion("v1alpha3", true, v1alpha1Schema.DeepCopy()),
+	)
+
+	// New CRD: v1alpha3 adds optional mountPath field and changes a description.
+	newCRD := createCRD(
+		withVersion("v1alpha1", true, v1alpha1Schema.DeepCopy()),
+		withVersion("v1alpha3", true, v1alpha3Schema.DeepCopy()),
+	)
+
+	validator := New(
+		WithComparators(typeComparator, descriptionComparator, requiredComparator),
+		WithUnhandledEnforcementPolicy(config.EnforcementPolicyError),
+	)
+
+	results := validator.Validate(oldCRD, newCRD)
+
+	for _, versionResult := range results {
+		for _, propResult := range versionResult.PropertyComparisons {
+			for _, compResult := range propResult.ComparisonResults {
+				assert.Empty(t, compResult.Errors,
+					"unexpected error for %s / %s / %s: %v",
+					versionResult.Version, propResult.Property, compResult.Name, compResult.Errors)
+			}
+		}
+	}
+}
+
 func TestValidator_New_DefaultValues(t *testing.T) {
 	validator := New()
 


### PR DESCRIPTION
Closes: https://github.com/kubernetes-sigs/crdify/issues/49
This PR fix the scenario described in: https://redhat.atlassian.net/browse/OCPBUGS-60693