### PR TITLE
tests: add e2e test for new optional list field

### DIFF
--- a/test/validchanges/a.yaml
+++ b/test/validchanges/a.yaml
@@ -57,6 +57,13 @@ spec:
                 - "Managed"
                 - "Unmanaged"
                 default: "Managed"
+              things:
+                description: Things is a list of things
+                items:
+                  properties:
+                    name:
+                      description: name is the name of a thing
+                      type: string
             type: object
             required:
             - size

--- a/test/validchanges/b.yaml
+++ b/test/validchanges/b.yaml
@@ -57,6 +57,17 @@ spec:
                 - "Managed"
                 - "Unmanaged"
                 default: "Managed"
+              things:
+                description: Things is a list of things
+                items:
+                  properties:
+                    name:
+                      description: name is the name of a thing
+                      type: string
+                    # New optional field within a list
+                    version:
+                      description: version is the version of a thing
+                      type: string
               # New optional field with no restrictions
               animal:
                 description: animal is the type of animal this instance represents


### PR DESCRIPTION
#### What this PR does:

Adds a new case to the `validchanges` e2e test to validate that adding a new optional field to a list is considered a valid change.

#### Which issue this PR is related to:

Proves #49 is not an issue with the latest changes.
