### PR TITLE
validations: add 'allOf' property validation

### DIFF
--- a/docs/validations.md
+++ b/docs/validations.md
@@ -149,6 +149,45 @@ validations:
       removalPolicy: Allow
 ```
 
+### allOf
+
+Validates compatibility of changes to a property's `allOf` constraints. The `allOf` keyword
+requires a value to satisfy all of the listed subschemas. Adding new subschemas tightens
+validation and may invalidate previously valid values.
+
+Incompatible changes are:
+
+- Adding an `allOf` constraint when there was none previously
+- Adding new subschemas to an existing `allOf` constraint
+- Removing subschemas from an existing `allOf` constraint
+
+#### Configuration
+
+The `allOf` validation has unique configuration options that can be used to change how it determines compatibility of a change to `allOf` constraints on a property:
+
+- `additionPolicy` - used to configure how compatibility is determined when adding new subschemas to an existing `allOf` constraint. Allowed values are `Allow` and `Disallow`. When set to `Allow`, adding a new subschema is considered a compatible change. When set to `Disallow`, adding a new subschema is considered an incompatible change. The default is `Disallow`.
+- `removalPolicy` - used to configure how compatibility is determined when removing subschemas from an existing `allOf` constraint. Allowed values are `Allow` and `Disallow`. When set to `Allow`, removing a subschema is considered a compatible change. When set to `Disallow`, removing a subschema is considered an incompatible change. The default is `Disallow`.
+
+An example of configuring the `allOf` validation to allow adding a new subschema:
+
+```yaml
+validations:
+  - name: allOf
+    enforcement: Error
+    configuration:
+      additionPolicy: Allow
+```
+
+An example of configuring the `allOf` validation to allow removing a subschema:
+
+```yaml
+validations:
+  - name: allOf
+    enforcement: Error
+    configuration:
+      removalPolicy: Allow
+```
+
 ### nullable
 
 Validates compatibility of changes to a property's nullable constraint. Allowing null values for a field

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -11,6 +11,12 @@ validations:
     enforcement: Error
     configuration:
       removalPolicy: Allow
+  # example of configuring allOf validation to allow addition of new subschemas and removal of existing subschemas
+  - name: allOf
+    enforcement: Error
+    configuration:
+      additionPolicy: Allow
+      removalPolicy: Allow
   # example of configuring nullable validation to allow making a field nullable and removing nullable support
   - name: nullable
     enforcement: Error

--- a/pkg/runner/registry.go
+++ b/pkg/runner/registry.go
@@ -45,6 +45,7 @@ func init() {
 	property.RegisterPattern(defaultRegistry)
 	property.RegisterNullable(defaultRegistry)
 	property.RegisterOneOf(defaultRegistry)
+	property.RegisterAllOf(defaultRegistry)
 }
 
 // DefaultRegistry returns a pre-configured validations.Registry.

--- a/pkg/validations/property/allof.go
+++ b/pkg/validations/property/allof.go
@@ -1,0 +1,198 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+const allOfValidationName = "allOf"
+
+var (
+	_ validations.Validation                                  = (*AllOf)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*AllOf)(nil)
+)
+
+// RegisterAllOf registers the AllOf validation
+// with the provided validation registry.
+func RegisterAllOf(registry validations.Registry) {
+	registry.Register(allOfValidationName, allOfFactory)
+}
+
+// allOfFactory is a function used to initialize an AllOf validation
+// implementation based on the provided configuration.
+func allOfFactory(cfg map[string]interface{}) (validations.Validation, error) {
+	allOfCfg := &AllOfConfig{}
+
+	err := ConfigToType(cfg, allOfCfg)
+	if err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	err = ValidateAllOfConfig(allOfCfg)
+	if err != nil {
+		return nil, fmt.Errorf("validating allOf config: %w", err)
+	}
+
+	return &AllOf{AllOfConfig: *allOfCfg}, nil
+}
+
+// ValidateAllOfConfig ensures provided AllOfConfig is valid and defaults missing values.
+func ValidateAllOfConfig(in *AllOfConfig) error {
+	if in == nil {
+		return nil
+	}
+
+	switch in.AdditionPolicy {
+	case AllOfAdditionPolicyAllow, AllOfAdditionPolicyDisallow:
+	case AllOfAdditionPolicy(""):
+		in.AdditionPolicy = AllOfAdditionPolicyDisallow
+	default:
+		return fmt.Errorf("%w : %q (valid values: %q, %q)", errUnknownAllOfAdditionPolicy, in.AdditionPolicy, AllOfAdditionPolicyAllow, AllOfAdditionPolicyDisallow)
+	}
+
+	switch in.RemovalPolicy {
+	case AllOfRemovalPolicyAllow, AllOfRemovalPolicyDisallow:
+	case AllOfRemovalPolicy(""):
+		in.RemovalPolicy = AllOfRemovalPolicyDisallow
+	default:
+		return fmt.Errorf("%w : %q (valid values: %q, %q)", errUnknownAllOfRemovalPolicy, in.RemovalPolicy, AllOfRemovalPolicyAllow, AllOfRemovalPolicyDisallow)
+	}
+
+	return nil
+}
+
+var (
+	errUnknownAllOfAdditionPolicy = errors.New("unknown addition policy")
+	errUnknownAllOfRemovalPolicy  = errors.New("unknown removal policy")
+)
+
+// AllOfAdditionPolicy represents how adding allOf subschemas should be evaluated.
+type AllOfAdditionPolicy string
+
+const (
+	// AllOfAdditionPolicyAllow treats adding allOf subschemas as compatible.
+	AllOfAdditionPolicyAllow AllOfAdditionPolicy = "Allow"
+	// AllOfAdditionPolicyDisallow treats adding allOf subschemas as incompatible.
+	AllOfAdditionPolicyDisallow AllOfAdditionPolicy = "Disallow"
+)
+
+// AllOfRemovalPolicy represents how removing allOf subschemas should be evaluated.
+type AllOfRemovalPolicy string
+
+const (
+	// AllOfRemovalPolicyAllow treats removing allOf subschemas as compatible.
+	AllOfRemovalPolicyAllow AllOfRemovalPolicy = "Allow"
+	// AllOfRemovalPolicyDisallow treats removing allOf subschemas as incompatible.
+	AllOfRemovalPolicyDisallow AllOfRemovalPolicy = "Disallow"
+)
+
+// AllOfConfig contains additional configuration for the AllOf validation.
+type AllOfConfig struct {
+	// AdditionPolicy dictates whether adding allOf subschemas is compatible.
+	// Allowed values are Allow and Disallow. Defaults to Disallow.
+	AdditionPolicy AllOfAdditionPolicy `json:"additionPolicy,omitempty"`
+	// RemovalPolicy dictates whether removing allOf subschemas is compatible.
+	// Allowed values are Allow and Disallow. Defaults to Disallow.
+	RemovalPolicy AllOfRemovalPolicy `json:"removalPolicy,omitempty"`
+}
+
+// AllOf is a Validation that can be used to identify
+// incompatible changes to the allOf constraints of CRD properties.
+type AllOf struct {
+	AllOfConfig
+	enforcement config.EnforcementPolicy
+}
+
+// Name returns the name of the AllOf validation.
+func (ao *AllOf) Name() string {
+	return allOfValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the AllOf validation.
+func (ao *AllOf) SetEnforcement(policy config.EnforcementPolicy) {
+	ao.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the allOf constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.AllOf field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (ao *AllOf) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	oldSchemas := sets.New[string]()
+
+	for i := range a.AllOf {
+		normalizeAllOfSchema(&a.AllOf[i])
+		oldSchemas.Insert(a.AllOf[i].String())
+	}
+
+	newSchemas := sets.New[string]()
+
+	for i := range b.AllOf {
+		normalizeAllOfSchema(&b.AllOf[i])
+		newSchemas.Insert(b.AllOf[i].String())
+	}
+
+	removedSchemas := oldSchemas.Difference(newSchemas)
+	addedSchemas := newSchemas.Difference(oldSchemas)
+
+	var err error
+
+	switch {
+	case oldSchemas.Len() == 0 && newSchemas.Len() > 0:
+		newSchemaSlice := newSchemas.UnsortedList()
+		slices.Sort(newSchemaSlice)
+		err = fmt.Errorf("%w : %v", ErrNetNewAllOfConstraint, newSchemaSlice)
+	case removedSchemas.Len() > 0 && ao.RemovalPolicy != AllOfRemovalPolicyAllow:
+		removedSchemaSlice := removedSchemas.UnsortedList()
+		slices.Sort(removedSchemaSlice)
+		err = fmt.Errorf("%w : %v", ErrAllOfConstraintRemoved, removedSchemaSlice)
+	case addedSchemas.Len() > 0 && ao.AdditionPolicy != AllOfAdditionPolicyAllow:
+		addedSchemaSlice := addedSchemas.UnsortedList()
+		slices.Sort(addedSchemaSlice)
+		err = fmt.Errorf("%w : %v", ErrAllOfConstraintAdded, addedSchemaSlice)
+	}
+
+	a.AllOf = nil
+	b.AllOf = nil
+
+	return validations.HandleErrors(ao.Name(), ao.enforcement, err)
+}
+
+// normalizeAllOfSchema zeroes non-structural fields on a schema
+// so that only validation-relevant differences are compared.
+func normalizeAllOfSchema(schema *apiextensionsv1.JSONSchemaProps) {
+	schema.Description = ""
+	schema.Title = ""
+	schema.Example = nil
+	schema.ExternalDocs = nil
+}
+
+var (
+	// ErrNetNewAllOfConstraint represents an error state where a net new allOf constraint was added to a property.
+	ErrNetNewAllOfConstraint = errors.New("allOf constraint added when there was none previously")
+	// ErrAllOfConstraintAdded represents an error state where new subschemas were added to an existing allOf constraint.
+	ErrAllOfConstraintAdded = errors.New("allOf subschema(s) added")
+	// ErrAllOfConstraintRemoved represents an error state where subschemas were removed from an existing allOf constraint.
+	ErrAllOfConstraintRemoved = errors.New("allOf subschema(s) removed")
+)

--- a/pkg/validations/property/allof_test.go
+++ b/pkg/validations/property/allof_test.go
@@ -1,0 +1,349 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"errors"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/ptr"
+	internaltesting "sigs.k8s.io/crdify/pkg/validations/internal/testing"
+)
+
+func TestAllOf(t *testing.T) {
+	testcases := []internaltesting.Testcase[apiextensionsv1.JSONSchemaProps]{
+		{
+			Name: "no diff, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			Flagged:              false,
+			ComparableValidation: &AllOf{},
+		},
+		{
+			Name: "no diff different order, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+					{MaxLength: ptr.To[int64](100)},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MaxLength: ptr.To[int64](100)},
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			Flagged:              false,
+			ComparableValidation: &AllOf{},
+		},
+		{
+			Name: "both empty, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{},
+			},
+			Flagged:              false,
+			ComparableValidation: &AllOf{},
+		},
+		{
+			Name: "net new allOf constraint, flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			Flagged:              true,
+			ComparableValidation: &AllOf{},
+		},
+		{
+			Name: "net new allOf constraint from nil, flagged",
+			Old:  &apiextensionsv1.JSONSchemaProps{},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			Flagged:              true,
+			ComparableValidation: &AllOf{},
+		},
+		{
+			Name: "net new allOf constraint, addition policy Allow does not suppress, flagged",
+			Old:  &apiextensionsv1.JSONSchemaProps{},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			Flagged: true,
+			ComparableValidation: &AllOf{
+				AllOfConfig: AllOfConfig{AdditionPolicy: AllOfAdditionPolicyAllow},
+			},
+		},
+		{
+			Name: "subschema added to existing allOf, flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+					{MaxLength: ptr.To[int64](100)},
+				},
+			},
+			Flagged:              true,
+			ComparableValidation: &AllOf{},
+		},
+		{
+			Name: "subschema added to existing allOf, addition policy set to Disallow, flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+					{MaxLength: ptr.To[int64](100)},
+				},
+			},
+			Flagged: true,
+			ComparableValidation: &AllOf{
+				AllOfConfig: AllOfConfig{AdditionPolicy: AllOfAdditionPolicyDisallow},
+			},
+		},
+		{
+			Name: "subschema added to existing allOf, addition policy set to Allow, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+					{MaxLength: ptr.To[int64](100)},
+				},
+			},
+			Flagged: false,
+			ComparableValidation: &AllOf{
+				AllOfConfig: AllOfConfig{AdditionPolicy: AllOfAdditionPolicyAllow},
+			},
+		},
+		{
+			Name: "subschema removed from existing allOf, flagged by default",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+					{MaxLength: ptr.To[int64](100)},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			Flagged:              true,
+			ComparableValidation: &AllOf{},
+		},
+		{
+			Name: "subschema removed from existing allOf, allowed via config",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+					{MaxLength: ptr.To[int64](100)},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			Flagged: false,
+			ComparableValidation: &AllOf{
+				AllOfConfig: AllOfConfig{RemovalPolicy: AllOfRemovalPolicyAllow},
+			},
+		},
+		{
+			Name: "subschema changed, flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](5)},
+				},
+			},
+			Flagged:              true,
+			ComparableValidation: &AllOf{},
+		},
+		{
+			Name: "subschema changed, removal allowed, flagged via addition",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](5)},
+				},
+			},
+			Flagged: true,
+			ComparableValidation: &AllOf{
+				AllOfConfig: AllOfConfig{RemovalPolicy: AllOfRemovalPolicyAllow},
+			},
+		},
+		{
+			Name: "all subschemas removed, flagged by default",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			New:                  &apiextensionsv1.JSONSchemaProps{},
+			Flagged:              true,
+			ComparableValidation: &AllOf{},
+		},
+		{
+			Name: "all subschemas removed, allowed via config",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{MinLength: ptr.To[int64](1)},
+				},
+			},
+			New:     &apiextensionsv1.JSONSchemaProps{},
+			Flagged: false,
+			ComparableValidation: &AllOf{
+				AllOfConfig: AllOfConfig{RemovalPolicy: AllOfRemovalPolicyAllow},
+			},
+		},
+		{
+			Name: "different field changed, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				ID: "foo",
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				ID: "bar",
+			},
+			Flagged:              false,
+			ComparableValidation: &AllOf{},
+		},
+	}
+
+	internaltesting.RunTestcases(t, testcases...)
+}
+
+func TestValidateAllOfConfig(t *testing.T) {
+	testcases := []struct {
+		name          string
+		cfg           *AllOfConfig
+		wantErr       error
+		wantAddPolicy AllOfAdditionPolicy
+		wantRemPolicy AllOfRemovalPolicy
+	}{
+		{
+			name: "nil config",
+			cfg:  nil,
+		},
+		{
+			name:          "defaults both policies",
+			cfg:           &AllOfConfig{},
+			wantAddPolicy: AllOfAdditionPolicyDisallow,
+			wantRemPolicy: AllOfRemovalPolicyDisallow,
+		},
+		{
+			name:          "allows valid addition policy Allow",
+			cfg:           &AllOfConfig{AdditionPolicy: AllOfAdditionPolicyAllow},
+			wantAddPolicy: AllOfAdditionPolicyAllow,
+			wantRemPolicy: AllOfRemovalPolicyDisallow,
+		},
+		{
+			name:          "allows valid addition policy Disallow",
+			cfg:           &AllOfConfig{AdditionPolicy: AllOfAdditionPolicyDisallow},
+			wantAddPolicy: AllOfAdditionPolicyDisallow,
+			wantRemPolicy: AllOfRemovalPolicyDisallow,
+		},
+		{
+			name:    "invalid addition policy",
+			cfg:     &AllOfConfig{AdditionPolicy: "invalid"},
+			wantErr: errUnknownAllOfAdditionPolicy,
+		},
+		{
+			name:          "allows valid removal policy Allow",
+			cfg:           &AllOfConfig{RemovalPolicy: AllOfRemovalPolicyAllow},
+			wantAddPolicy: AllOfAdditionPolicyDisallow,
+			wantRemPolicy: AllOfRemovalPolicyAllow,
+		},
+		{
+			name:          "allows valid removal policy Disallow",
+			cfg:           &AllOfConfig{RemovalPolicy: AllOfRemovalPolicyDisallow},
+			wantAddPolicy: AllOfAdditionPolicyDisallow,
+			wantRemPolicy: AllOfRemovalPolicyDisallow,
+		},
+		{
+			name:    "invalid removal policy",
+			cfg:     &AllOfConfig{RemovalPolicy: "invalid"},
+			wantErr: errUnknownAllOfRemovalPolicy,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAllOfConfig(tc.cfg)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.cfg == nil {
+				return
+			}
+
+			if tc.wantAddPolicy != "" && tc.cfg.AdditionPolicy != tc.wantAddPolicy {
+				t.Fatalf("expected addition policy %q, got %q", tc.wantAddPolicy, tc.cfg.AdditionPolicy)
+			}
+
+			if tc.wantRemPolicy != "" && tc.cfg.RemovalPolicy != tc.wantRemPolicy {
+				t.Fatalf("expected removal policy %q, got %q", tc.wantRemPolicy, tc.cfg.RemovalPolicy)
+			}
+		})
+	}
+}

--- a/test/allofadded/a.yaml
+++ b/test/allofadded/a.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: allofexamples.example.com
+spec:
+  group: example.com
+  names:
+    kind: AllOfExample
+    listKind: AllOfExampleList
+    plural: allofexamples
+    singular: allofexample
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              port:
+                type: integer

--- a/test/allofadded/b.yaml
+++ b/test/allofadded/b.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: allofexamples.example.com
+spec:
+  group: example.com
+  names:
+    kind: AllOfExample
+    listKind: AllOfExampleList
+    plural: allofexamples
+    singular: allofexample
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              port:
+                type: integer
+                allOf:
+                - minimum: 1
+                - maximum: 65535

--- a/test/allofadded/expected.json
+++ b/test/allofadded/expected.json
@@ -1,0 +1,20 @@
+{
+ "sameVersionValidation": [
+  {
+   "version": "v1",
+   "propertyComparisons": [
+    {
+     "property": "^.spec.port",
+     "comparisonResults": [
+      {
+       "name": "allOf",
+       "errors": [
+        "allOf constraint added when there was none previously : [\u0026JSONSchemaProps{ID:,Schema:,Ref:nil,Description:,Type:,Format:,Title:,Default:nil,Maximum:*65535,ExclusiveMaximum:false,Minimum:nil,ExclusiveMinimum:false,MaxLength:nil,MinLength:nil,Pattern:,MaxItems:nil,MinItems:nil,UniqueItems:false,MultipleOf:nil,Enum:[]JSON{},MaxProperties:nil,MinProperties:nil,Required:[],Items:nil,AllOf:[]JSONSchemaProps{},OneOf:[]JSONSchemaProps{},AnyOf:[]JSONSchemaProps{},Not:nil,Properties:map[string]JSONSchemaProps{},AdditionalProperties:nil,PatternProperties:map[string]JSONSchemaProps{},Dependencies:JSONSchemaDependencies{},AdditionalItems:nil,Definitions:JSONSchemaDefinitions{},ExternalDocs:nil,Example:nil,Nullable:false,XPreserveUnknownFields:nil,XEmbeddedResource:false,XIntOrString:false,XListMapKeys:[],XListType:nil,XMapType:nil,XValidations:[]ValidationRule{},} \u0026JSONSchemaProps{ID:,Schema:,Ref:nil,Description:,Type:,Format:,Title:,Default:nil,Maximum:nil,ExclusiveMaximum:false,Minimum:*1,ExclusiveMinimum:false,MaxLength:nil,MinLength:nil,Pattern:,MaxItems:nil,MinItems:nil,UniqueItems:false,MultipleOf:nil,Enum:[]JSON{},MaxProperties:nil,MinProperties:nil,Required:[],Items:nil,AllOf:[]JSONSchemaProps{},OneOf:[]JSONSchemaProps{},AnyOf:[]JSONSchemaProps{},Not:nil,Properties:map[string]JSONSchemaProps{},AdditionalProperties:nil,PatternProperties:map[string]JSONSchemaProps{},Dependencies:JSONSchemaDependencies{},AdditionalItems:nil,Definitions:JSONSchemaDefinitions{},ExternalDocs:nil,Example:nil,Nullable:false,XPreserveUnknownFields:nil,XEmbeddedResource:false,XIntOrString:false,XListMapKeys:[],XListType:nil,XMapType:nil,XValidations:[]ValidationRule{},}]"
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/test/allofremoved/a.yaml
+++ b/test/allofremoved/a.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: allofexamples.example.com
+spec:
+  group: example.com
+  names:
+    kind: AllOfExample
+    listKind: AllOfExampleList
+    plural: allofexamples
+    singular: allofexample
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              port:
+                type: integer
+                allOf:
+                - minimum: 1
+                - maximum: 65535

--- a/test/allofremoved/b.yaml
+++ b/test/allofremoved/b.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: allofexamples.example.com
+spec:
+  group: example.com
+  names:
+    kind: AllOfExample
+    listKind: AllOfExampleList
+    plural: allofexamples
+    singular: allofexample
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              port:
+                type: integer

--- a/test/allofremoved/expected.json
+++ b/test/allofremoved/expected.json
@@ -1,0 +1,29 @@
+{
+ "crdValidation": [
+  {
+   "name": "existingFieldRemoval",
+   "errors": [
+    "removed field : v1.^.spec.port.allOf[1]",
+    "removed field : v1.^.spec.port.allOf[0]"
+   ]
+  }
+ ],
+ "sameVersionValidation": [
+  {
+   "version": "v1",
+   "propertyComparisons": [
+    {
+     "property": "^.spec.port",
+     "comparisonResults": [
+      {
+       "name": "allOf",
+       "errors": [
+        "allOf subschema(s) removed : [\u0026JSONSchemaProps{ID:,Schema:,Ref:nil,Description:,Type:,Format:,Title:,Default:nil,Maximum:*65535,ExclusiveMaximum:false,Minimum:nil,ExclusiveMinimum:false,MaxLength:nil,MinLength:nil,Pattern:,MaxItems:nil,MinItems:nil,UniqueItems:false,MultipleOf:nil,Enum:[]JSON{},MaxProperties:nil,MinProperties:nil,Required:[],Items:nil,AllOf:[]JSONSchemaProps{},OneOf:[]JSONSchemaProps{},AnyOf:[]JSONSchemaProps{},Not:nil,Properties:map[string]JSONSchemaProps{},AdditionalProperties:nil,PatternProperties:map[string]JSONSchemaProps{},Dependencies:JSONSchemaDependencies{},AdditionalItems:nil,Definitions:JSONSchemaDefinitions{},ExternalDocs:nil,Example:nil,Nullable:false,XPreserveUnknownFields:nil,XEmbeddedResource:false,XIntOrString:false,XListMapKeys:[],XListType:nil,XMapType:nil,XValidations:[]ValidationRule{},} \u0026JSONSchemaProps{ID:,Schema:,Ref:nil,Description:,Type:,Format:,Title:,Default:nil,Maximum:nil,ExclusiveMaximum:false,Minimum:*1,ExclusiveMinimum:false,MaxLength:nil,MinLength:nil,Pattern:,MaxItems:nil,MinItems:nil,UniqueItems:false,MultipleOf:nil,Enum:[]JSON{},MaxProperties:nil,MinProperties:nil,Required:[],Items:nil,AllOf:[]JSONSchemaProps{},OneOf:[]JSONSchemaProps{},AnyOf:[]JSONSchemaProps{},Not:nil,Properties:map[string]JSONSchemaProps{},AdditionalProperties:nil,PatternProperties:map[string]JSONSchemaProps{},Dependencies:JSONSchemaDependencies{},AdditionalItems:nil,Definitions:JSONSchemaDefinitions{},ExternalDocs:nil,Example:nil,Nullable:false,XPreserveUnknownFields:nil,XEmbeddedResource:false,XIntOrString:false,XListMapKeys:[],XListType:nil,XMapType:nil,XValidations:[]ValidationRule{},}]"
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
#### What this PR does:
Adds a property validation for the `allOf` JSON Schema keyword. It detects incompatible changes to `allOf` constraints on CRD properties:
- Adding an `allOf` constraint when there was none previously
- Adding new subschemas to an existing `allOf` constraint
- Removing subschemas from an existing `allOf` constraint

Both additions and removals are treated as incompatible by default. An `additionPolicy` and `removalPolicy` configuration knob allow users to opt into treating additions or removals as compatible when appropriate for their reader/writer considerations.

Uses `sets.Set` with stringified schemas for diffing, matching the approach in #64.

#### Which issue this PR is related to:
Fixes #24