### PR TITLE
Property Validation: oneOf

### DIFF
--- a/docs/validations.md
+++ b/docs/validations.md
@@ -181,3 +181,29 @@ validations:
     configuration:
       removalPolicy: Allow
 ```
+
+### oneOf
+
+Validates compatibility of changes to the `oneOf` constraint on a property. The `oneOf` constraint restricts a property's value to matching exactly one of the listed subschemas.
+
+Incompatible changes are:
+
+- Adding a `oneOf` constraint when there was none previously
+- Removing a previously allowed subschema from a `oneOf` constraint
+- Adding a new subschema to a `oneOf` constraint
+
+#### Configuration
+
+The `oneOf` validation has unique configuration options that can be used to change how it determines compatibility of a change to `oneOf` constraints on a property:
+
+- `additionPolicy` - used to configure how compatibility is determined when adding new subschemas to an existing `oneOf` constraint. Allowed values are `Allow` and `Disallow`. When set to `Allow`, adding a new subschema is considered a compatible change. When set to `Disallow`, adding a new subschema is considered an incompatible change. The default is `Disallow`.
+
+An example of configuring the `oneOf` validation to allow adding a new subschema:
+
+```yaml
+validations:
+  - name: oneOf
+    enforcement: Error
+    configuration:
+      additionPolicy: Allow
+```

--- a/docs/validations.md
+++ b/docs/validations.md
@@ -197,6 +197,7 @@ Incompatible changes are:
 The `oneOf` validation has unique configuration options that can be used to change how it determines compatibility of a change to `oneOf` constraints on a property:
 
 - `additionPolicy` - used to configure how compatibility is determined when adding new subschemas to an existing `oneOf` constraint. Allowed values are `Allow` and `Disallow`. When set to `Allow`, adding a new subschema is considered a compatible change. When set to `Disallow`, adding a new subschema is considered an incompatible change. The default is `Disallow`.
+- `removalPolicy` - used to configure how compatibility is determined when removing subschemas from an existing `oneOf` constraint. Allowed values are `Allow` and `Disallow`. When set to `Allow`, removing a subschema is considered a compatible change. When set to `Disallow`, removing a subschema is considered an incompatible change. The default is `Disallow`.
 
 An example of configuring the `oneOf` validation to allow adding a new subschema:
 
@@ -206,4 +207,14 @@ validations:
     enforcement: Error
     configuration:
       additionPolicy: Allow
+```
+
+An example of configuring the `oneOf` validation to allow removing a subschema:
+
+```yaml
+validations:
+  - name: oneOf
+    enforcement: Error
+    configuration:
+      removalPolicy: Allow
 ```

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -17,3 +17,8 @@ validations:
     configuration:
       additionPolicy: Allow
       removalPolicy: Allow
+  # example of configuring oneOf validation to allow addition of new subschemas
+  - name: oneOf
+    enforcement: Error
+    configuration:
+      additionPolicy: Allow

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -17,8 +17,9 @@ validations:
     configuration:
       additionPolicy: Allow
       removalPolicy: Allow
-  # example of configuring oneOf validation to allow addition of new subschemas
+  # example of configuring oneOf validation to allow addition of new subschemas and removal of existing subschemas
   - name: oneOf
     enforcement: Error
     configuration:
       additionPolicy: Allow
+      removalPolicy: Allow

--- a/pkg/runner/registry.go
+++ b/pkg/runner/registry.go
@@ -44,6 +44,7 @@ func init() {
 	property.RegisterDescription(defaultRegistry)
 	property.RegisterPattern(defaultRegistry)
 	property.RegisterNullable(defaultRegistry)
+	property.RegisterOneOf(defaultRegistry)
 }
 
 // DefaultRegistry returns a pre-configured validations.Registry.

--- a/pkg/validations/property/oneof.go
+++ b/pkg/validations/property/oneof.go
@@ -189,14 +189,18 @@ func (o *OneOf) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.Compa
 // pre-existing property schema is preserved as one of the new oneOf
 // entries, the change is considered compatible.
 func (o *OneOf) checkNetNewOneOf(old *apiextensionsv1.JSONSchemaProps, newSchemas sets.Set[string]) error {
-	if o.AdditionPolicy == AdditionPolicyAllow && preExistingSchemaPreserved(old, newSchemas) {
-		return nil
-	}
-
 	newSchemaSlice := newSchemas.UnsortedList()
 	slices.Sort(newSchemaSlice)
 
-	return fmt.Errorf("%w: %v", ErrNetNewOneOfConstraint, newSchemaSlice)
+	if o.AdditionPolicy != AdditionPolicyAllow {
+		return fmt.Errorf("%w: %v", ErrNetNewOneOfConstraint, newSchemaSlice)
+	}
+
+	if !preExistingSchemaPreserved(old, newSchemas) {
+		return fmt.Errorf("%w: %v", ErrNetNewOneOfPreExistingSchemaNotPreserved, newSchemaSlice)
+	}
+
+	return nil
 }
 
 // preExistingSchemaPreserved checks whether the old property schema
@@ -204,9 +208,9 @@ func (o *OneOf) checkNetNewOneOf(old *apiextensionsv1.JSONSchemaProps, newSchema
 // new oneOf constraint. This is used to determine if a net-new oneOf
 // is a safe loosening change for writer-focused APIs.
 func preExistingSchemaPreserved(old *apiextensionsv1.JSONSchemaProps, newSchemas sets.Set[string]) bool {
-	oldCopy := *old
+	oldCopy := old.DeepCopy()
 	oldCopy.OneOf = nil
-	normalizeSchema(&oldCopy)
+	normalizeSchema(oldCopy)
 
 	return newSchemas.Has(oldCopy.String())
 }
@@ -223,6 +227,9 @@ func normalizeSchema(schema *apiextensionsv1.JSONSchemaProps) {
 var (
 	// ErrNetNewOneOfConstraint represents an error state where a net new oneOf constraint was added to a property.
 	ErrNetNewOneOfConstraint = errors.New("oneOf constraint added when there was none previously")
+	// ErrNetNewOneOfPreExistingSchemaNotPreserved represents an error state where a net new oneOf constraint was added
+	// but the pre-existing property schema is not preserved as one of the new oneOf entries, breaking both readers and writers.
+	ErrNetNewOneOfPreExistingSchemaNotPreserved = errors.New("oneOf constraint added and pre-existing property schema is not preserved in the new oneOf entries")
 	// ErrRemovedOneOf represents an error state where at least one previously allowed oneOf subschema was removed
 	// from the oneOf constraint on a property.
 	ErrRemovedOneOf = errors.New("allowed oneOf schemas removed")

--- a/pkg/validations/property/oneof.go
+++ b/pkg/validations/property/oneof.go
@@ -15,7 +15,6 @@
 package property
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -59,9 +58,6 @@ func oneOfFactory(cfg map[string]interface{}) (validations.Validation, error) {
 
 // ValidateOneOfConfig validates the provided OneOfConfig
 // setting default values where appropriate.
-// Currently the defaulting behavior defaults the
-// OneOfConfig.AdditionPolicy to AdditionPolicyDisallow
-// if it is set to the empty string ("").
 func ValidateOneOfConfig(in *OneOfConfig) error {
 	if in == nil {
 		return nil
@@ -76,8 +72,33 @@ func ValidateOneOfConfig(in *OneOfConfig) error {
 		return fmt.Errorf("%w : %q", errUnknownAdditionPolicy, in.AdditionPolicy)
 	}
 
+	switch in.RemovalPolicy {
+	case RemovalPolicyAllow, RemovalPolicyDisallow:
+		// do nothing, valid case
+	case RemovalPolicy(""):
+		in.RemovalPolicy = RemovalPolicyDisallow
+	default:
+		return fmt.Errorf("%w : %q", errUnknownRemovalPolicy, in.RemovalPolicy)
+	}
+
 	return nil
 }
+
+// RemovalPolicy is used to represent how a validation
+// should determine compatibility of removing existing constraints.
+type RemovalPolicy string
+
+const (
+	// RemovalPolicyAllow signals that removing an existing constraint
+	// should be considered a compatible change.
+	RemovalPolicyAllow RemovalPolicy = "Allow"
+
+	// RemovalPolicyDisallow signals that removing an existing constraint
+	// should be considered an incompatible change.
+	RemovalPolicyDisallow RemovalPolicy = "Disallow"
+)
+
+var errUnknownRemovalPolicy = errors.New("unknown removal policy")
 
 // OneOfConfig contains additional configurations for the OneOf validation.
 type OneOfConfig struct {
@@ -90,6 +111,15 @@ type OneOfConfig struct {
 	// oneOf constraint will be flagged.
 	// Defaults to Disallow.
 	AdditionPolicy AdditionPolicy `json:"additionPolicy,omitempty"`
+	// removalPolicy is how removing subschemas from an existing oneOf
+	// constraint should be treated.
+	// Allowed values are Allow and Disallow.
+	// When set to Allow, removing subschemas from an existing
+	// oneOf constraint will not be flagged.
+	// When set to Disallow, removing subschemas from an existing
+	// oneOf constraint will be flagged.
+	// Defaults to Disallow.
+	RemovalPolicy RemovalPolicy `json:"removalPolicy,omitempty"`
 }
 
 // OneOf is a Validation that can be used to identify
@@ -119,29 +149,15 @@ func (o *OneOf) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.Compa
 	oldSchemas := sets.New[string]()
 
 	for i := range a.OneOf {
-		key, err := marshalSchema(a.OneOf[i])
-		if err != nil {
-			a.OneOf = nil
-			b.OneOf = nil
-
-			return validations.HandleErrors(o.Name(), o.enforcement, fmt.Errorf("marshaling old oneOf schema at index %d: %w", i, err))
-		}
-
-		oldSchemas.Insert(key)
+		normalizeSchema(&a.OneOf[i])
+		oldSchemas.Insert(a.OneOf[i].String())
 	}
 
 	newSchemas := sets.New[string]()
 
 	for i := range b.OneOf {
-		key, err := marshalSchema(b.OneOf[i])
-		if err != nil {
-			a.OneOf = nil
-			b.OneOf = nil
-
-			return validations.HandleErrors(o.Name(), o.enforcement, fmt.Errorf("marshaling new oneOf schema at index %d: %w", i, err))
-		}
-
-		newSchemas.Insert(key)
+		normalizeSchema(&b.OneOf[i])
+		newSchemas.Insert(b.OneOf[i].String())
 	}
 
 	removedSchemas := oldSchemas.Difference(newSchemas)
@@ -154,7 +170,7 @@ func (o *OneOf) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.Compa
 		newSchemaSlice := newSchemas.UnsortedList()
 		slices.Sort(newSchemaSlice)
 		err = fmt.Errorf("%w: %v", ErrNetNewOneOfConstraint, newSchemaSlice)
-	case removedSchemas.Len() > 0:
+	case removedSchemas.Len() > 0 && o.RemovalPolicy != RemovalPolicyAllow:
 		removedSchemaSlice := removedSchemas.UnsortedList()
 		slices.Sort(removedSchemaSlice)
 		err = fmt.Errorf("%w: %v", ErrRemovedOneOf, removedSchemaSlice)
@@ -170,19 +186,13 @@ func (o *OneOf) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.Compa
 	return validations.HandleErrors(o.Name(), o.enforcement, err)
 }
 
-// marshalSchema produces a canonical JSON string for a schema,
-// ignoring non-structural fields (Description, Example) so that
-// only validation-relevant differences are compared.
-func marshalSchema(schema apiextensionsv1.JSONSchemaProps) (string, error) {
+// normalizeSchema zeroes non-structural fields on a schema
+// so that only validation-relevant differences are compared.
+func normalizeSchema(schema *apiextensionsv1.JSONSchemaProps) {
 	schema.Description = ""
+	schema.Title = ""
 	schema.Example = nil
-
-	data, err := json.Marshal(schema)
-	if err != nil {
-		return "", fmt.Errorf("marshaling schema: %w", err)
-	}
-
-	return string(data), nil
+	schema.ExternalDocs = nil
 }
 
 var (

--- a/pkg/validations/property/oneof.go
+++ b/pkg/validations/property/oneof.go
@@ -167,9 +167,7 @@ func (o *OneOf) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.Compa
 
 	switch {
 	case oldSchemas.Len() == 0 && newSchemas.Len() > 0:
-		newSchemaSlice := newSchemas.UnsortedList()
-		slices.Sort(newSchemaSlice)
-		err = fmt.Errorf("%w: %v", ErrNetNewOneOfConstraint, newSchemaSlice)
+		err = o.checkNetNewOneOf(a, newSchemas)
 	case removedSchemas.Len() > 0 && o.RemovalPolicy != RemovalPolicyAllow:
 		removedSchemaSlice := removedSchemas.UnsortedList()
 		slices.Sort(removedSchemaSlice)
@@ -184,6 +182,33 @@ func (o *OneOf) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.Compa
 	b.OneOf = nil
 
 	return validations.HandleErrors(o.Name(), o.enforcement, err)
+}
+
+// checkNetNewOneOf evaluates whether a net-new oneOf constraint is
+// an incompatible change. When additionPolicy is Allow and the
+// pre-existing property schema is preserved as one of the new oneOf
+// entries, the change is considered compatible.
+func (o *OneOf) checkNetNewOneOf(old *apiextensionsv1.JSONSchemaProps, newSchemas sets.Set[string]) error {
+	if o.AdditionPolicy == AdditionPolicyAllow && preExistingSchemaPreserved(old, newSchemas) {
+		return nil
+	}
+
+	newSchemaSlice := newSchemas.UnsortedList()
+	slices.Sort(newSchemaSlice)
+
+	return fmt.Errorf("%w: %v", ErrNetNewOneOfConstraint, newSchemaSlice)
+}
+
+// preExistingSchemaPreserved checks whether the old property schema
+// (with its OneOf field cleared) appears as one of the entries in the
+// new oneOf constraint. This is used to determine if a net-new oneOf
+// is a safe loosening change for writer-focused APIs.
+func preExistingSchemaPreserved(old *apiextensionsv1.JSONSchemaProps, newSchemas sets.Set[string]) bool {
+	oldCopy := *old
+	oldCopy.OneOf = nil
+	normalizeSchema(&oldCopy)
+
+	return newSchemas.Has(oldCopy.String())
 }
 
 // normalizeSchema zeroes non-structural fields on a schema

--- a/pkg/validations/property/oneof.go
+++ b/pkg/validations/property/oneof.go
@@ -1,0 +1,197 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/crdify/pkg/config"
+	"sigs.k8s.io/crdify/pkg/validations"
+)
+
+const oneOfValidationName = "oneOf"
+
+var (
+	_ validations.Validation                                  = (*OneOf)(nil)
+	_ validations.Comparator[apiextensionsv1.JSONSchemaProps] = (*OneOf)(nil)
+)
+
+// RegisterOneOf registers the OneOf validation
+// with the provided validation registry.
+func RegisterOneOf(registry validations.Registry) {
+	registry.Register(oneOfValidationName, oneOfFactory)
+}
+
+// oneOfFactory is a function used to initialize a OneOf validation
+// implementation based on the provided configuration.
+func oneOfFactory(cfg map[string]interface{}) (validations.Validation, error) {
+	oneOfCfg := &OneOfConfig{}
+
+	err := ConfigToType(cfg, oneOfCfg)
+	if err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	err = ValidateOneOfConfig(oneOfCfg)
+	if err != nil {
+		return nil, fmt.Errorf("validating oneOf config: %w", err)
+	}
+
+	return &OneOf{OneOfConfig: *oneOfCfg}, nil
+}
+
+// ValidateOneOfConfig validates the provided OneOfConfig
+// setting default values where appropriate.
+// Currently the defaulting behavior defaults the
+// OneOfConfig.AdditionPolicy to AdditionPolicyDisallow
+// if it is set to the empty string ("").
+func ValidateOneOfConfig(in *OneOfConfig) error {
+	if in == nil {
+		return nil
+	}
+
+	switch in.AdditionPolicy {
+	case AdditionPolicyAllow, AdditionPolicyDisallow:
+		// do nothing, valid case
+	case AdditionPolicy(""):
+		in.AdditionPolicy = AdditionPolicyDisallow
+	default:
+		return fmt.Errorf("%w : %q", errUnknownAdditionPolicy, in.AdditionPolicy)
+	}
+
+	return nil
+}
+
+// OneOfConfig contains additional configurations for the OneOf validation.
+type OneOfConfig struct {
+	// additionPolicy is how adding subschemas to an existing oneOf
+	// constraint should be treated.
+	// Allowed values are Allow and Disallow.
+	// When set to Allow, adding new subschemas to an existing
+	// oneOf constraint will not be flagged.
+	// When set to Disallow, adding new subschemas to an existing
+	// oneOf constraint will be flagged.
+	// Defaults to Disallow.
+	AdditionPolicy AdditionPolicy `json:"additionPolicy,omitempty"`
+}
+
+// OneOf is a Validation that can be used to identify
+// incompatible changes to the oneOf constraint of CRD properties.
+type OneOf struct {
+	OneOfConfig
+
+	enforcement config.EnforcementPolicy
+}
+
+// Name returns the name of the OneOf validation.
+func (o *OneOf) Name() string {
+	return oneOfValidationName
+}
+
+// SetEnforcement sets the EnforcementPolicy for the OneOf validation.
+func (o *OneOf) SetEnforcement(policy config.EnforcementPolicy) {
+	o.enforcement = policy
+}
+
+// Compare compares an old and a new JSONSchemaProps, checking for incompatible changes to the oneOf constraints of a property.
+// In order for callers to determine if diffs to a JSONSchemaProps have been handled by this validation
+// the JSONSchemaProps.OneOf field will be reset to 'nil' as part of this method.
+// It is highly recommended that only copies of the JSONSchemaProps to compare are provided to this method
+// to prevent unintentional modifications.
+func (o *OneOf) Compare(a, b *apiextensionsv1.JSONSchemaProps) validations.ComparisonResult {
+	oldSchemas := sets.New[string]()
+
+	for i := range a.OneOf {
+		key, err := marshalSchema(a.OneOf[i])
+		if err != nil {
+			a.OneOf = nil
+			b.OneOf = nil
+
+			return validations.HandleErrors(o.Name(), o.enforcement, fmt.Errorf("marshaling old oneOf schema at index %d: %w", i, err))
+		}
+
+		oldSchemas.Insert(key)
+	}
+
+	newSchemas := sets.New[string]()
+
+	for i := range b.OneOf {
+		key, err := marshalSchema(b.OneOf[i])
+		if err != nil {
+			a.OneOf = nil
+			b.OneOf = nil
+
+			return validations.HandleErrors(o.Name(), o.enforcement, fmt.Errorf("marshaling new oneOf schema at index %d: %w", i, err))
+		}
+
+		newSchemas.Insert(key)
+	}
+
+	removedSchemas := oldSchemas.Difference(newSchemas)
+	addedSchemas := newSchemas.Difference(oldSchemas)
+
+	var err error
+
+	switch {
+	case oldSchemas.Len() == 0 && newSchemas.Len() > 0:
+		newSchemaSlice := newSchemas.UnsortedList()
+		slices.Sort(newSchemaSlice)
+		err = fmt.Errorf("%w: %v", ErrNetNewOneOfConstraint, newSchemaSlice)
+	case removedSchemas.Len() > 0:
+		removedSchemaSlice := removedSchemas.UnsortedList()
+		slices.Sort(removedSchemaSlice)
+		err = fmt.Errorf("%w: %v", ErrRemovedOneOf, removedSchemaSlice)
+	case addedSchemas.Len() > 0 && o.AdditionPolicy != AdditionPolicyAllow:
+		addedSchemaSlice := addedSchemas.UnsortedList()
+		slices.Sort(addedSchemaSlice)
+		err = fmt.Errorf("%w: %v", ErrAddedOneOf, addedSchemaSlice)
+	}
+
+	a.OneOf = nil
+	b.OneOf = nil
+
+	return validations.HandleErrors(o.Name(), o.enforcement, err)
+}
+
+// marshalSchema produces a canonical JSON string for a schema,
+// ignoring non-structural fields (Description, Example) so that
+// only validation-relevant differences are compared.
+func marshalSchema(schema apiextensionsv1.JSONSchemaProps) (string, error) {
+	schema.Description = ""
+	schema.Example = nil
+
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return "", fmt.Errorf("marshaling schema: %w", err)
+	}
+
+	return string(data), nil
+}
+
+var (
+	// ErrNetNewOneOfConstraint represents an error state where a net new oneOf constraint was added to a property.
+	ErrNetNewOneOfConstraint = errors.New("oneOf constraint added when there was none previously")
+	// ErrRemovedOneOf represents an error state where at least one previously allowed oneOf subschema was removed
+	// from the oneOf constraint on a property.
+	ErrRemovedOneOf = errors.New("allowed oneOf schemas removed")
+	// ErrAddedOneOf represents an error state where at least one oneOf subschema, that was not previously allowed,
+	// was added to the oneOf constraint on a property.
+	ErrAddedOneOf = errors.New("allowed oneOf schemas added")
+)

--- a/pkg/validations/property/oneof_test.go
+++ b/pkg/validations/property/oneof_test.go
@@ -1,0 +1,224 @@
+// Copyright 2025 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"errors"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	internaltesting "sigs.k8s.io/crdify/pkg/validations/internal/testing"
+)
+
+func TestOneOf(t *testing.T) {
+	testcases := []internaltesting.Testcase[apiextensionsv1.JSONSchemaProps]{
+		{
+			Name: "no diff, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+				},
+			},
+			Flagged:              false,
+			ComparableValidation: &OneOf{},
+		},
+		{
+			Name: "no diff different order, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+					{Type: "string"},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "string"},
+					{Type: "integer"},
+				},
+			},
+			Flagged:              false,
+			ComparableValidation: &OneOf{},
+		},
+		{
+			Name: "new oneOf constraint, flagged",
+			Old:  &apiextensionsv1.JSONSchemaProps{},
+			New: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+				},
+			},
+			Flagged:              true,
+			ComparableValidation: &OneOf{},
+		},
+		{
+			Name: "removed oneOf subschema, flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+					{Type: "string"},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "string"},
+				},
+			},
+			Flagged:              true,
+			ComparableValidation: &OneOf{},
+		},
+		{
+			Name: "new allowed oneOf subschema added, addition policy not set, flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+					{Type: "string"},
+				},
+			},
+			Flagged:              true,
+			ComparableValidation: &OneOf{},
+		},
+		{
+			Name: "new allowed oneOf subschema added, addition policy set to Disallow, flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+					{Type: "string"},
+				},
+			},
+			Flagged: true,
+			ComparableValidation: &OneOf{
+				OneOfConfig: OneOfConfig{
+					AdditionPolicy: AdditionPolicyDisallow,
+				},
+			},
+		},
+		{
+			Name: "new allowed oneOf subschema added, addition policy set to Allow, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+					{Type: "string"},
+				},
+			},
+			Flagged: false,
+			ComparableValidation: &OneOf{
+				OneOfConfig: OneOfConfig{
+					AdditionPolicy: AdditionPolicyAllow,
+				},
+			},
+		},
+		{
+			Name: "different field changed, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				ID: "foo",
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				ID: "bar",
+			},
+			Flagged:              false,
+			ComparableValidation: &OneOf{},
+		},
+		{
+			Name: "different field changed with oneOf, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				ID: "foo",
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				ID: "bar",
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+				},
+			},
+			Flagged:              false,
+			ComparableValidation: &OneOf{},
+		},
+	}
+
+	internaltesting.RunTestcases(t, testcases...)
+}
+
+func TestValidateOneOfConfig(t *testing.T) {
+	testcases := []struct {
+		name               string
+		cfg                *OneOfConfig
+		wantErr            error
+		wantAdditionPolicy AdditionPolicy
+	}{
+		{
+			name: "nil config",
+			cfg:  nil,
+		},
+		{
+			name:               "defaults addition policy",
+			cfg:                &OneOfConfig{},
+			wantAdditionPolicy: AdditionPolicyDisallow,
+		},
+		{
+			name:               "allows valid addition policies",
+			cfg:                &OneOfConfig{AdditionPolicy: AdditionPolicyAllow},
+			wantAdditionPolicy: AdditionPolicyAllow,
+		},
+		{
+			name:    "invalid addition policy",
+			cfg:     &OneOfConfig{AdditionPolicy: "invalid"},
+			wantErr: errUnknownAdditionPolicy,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateOneOfConfig(tc.cfg)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.cfg != nil && tc.cfg.AdditionPolicy != tc.wantAdditionPolicy {
+				t.Fatalf("expected addition policy %q, got %q", tc.wantAdditionPolicy, tc.cfg.AdditionPolicy)
+			}
+		})
+	}
+}

--- a/pkg/validations/property/oneof_test.go
+++ b/pkg/validations/property/oneof_test.go
@@ -68,6 +68,41 @@ func TestOneOf(t *testing.T) {
 			ComparableValidation: &OneOf{},
 		},
 		{
+			Name: "new oneOf constraint, addition policy set to Allow, pre-existing schema preserved, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				Type: "integer",
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+					{Type: "string"},
+				},
+			},
+			Flagged: false,
+			ComparableValidation: &OneOf{
+				OneOfConfig: OneOfConfig{
+					AdditionPolicy: AdditionPolicyAllow,
+				},
+			},
+		},
+		{
+			Name: "new oneOf constraint, addition policy set to Allow, pre-existing schema not preserved, flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				Type: "string",
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+				},
+			},
+			Flagged: true,
+			ComparableValidation: &OneOf{
+				OneOfConfig: OneOfConfig{
+					AdditionPolicy: AdditionPolicyAllow,
+				},
+			},
+		},
+		{
 			Name: "removed oneOf subschema, removal policy not set, flagged",
 			Old: &apiextensionsv1.JSONSchemaProps{
 				OneOf: []apiextensionsv1.JSONSchemaProps{

--- a/pkg/validations/property/oneof_test.go
+++ b/pkg/validations/property/oneof_test.go
@@ -68,7 +68,7 @@ func TestOneOf(t *testing.T) {
 			ComparableValidation: &OneOf{},
 		},
 		{
-			Name: "removed oneOf subschema, flagged",
+			Name: "removed oneOf subschema, removal policy not set, flagged",
 			Old: &apiextensionsv1.JSONSchemaProps{
 				OneOf: []apiextensionsv1.JSONSchemaProps{
 					{Type: "integer"},
@@ -82,6 +82,46 @@ func TestOneOf(t *testing.T) {
 			},
 			Flagged:              true,
 			ComparableValidation: &OneOf{},
+		},
+		{
+			Name: "removed oneOf subschema, removal policy set to Disallow, flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+					{Type: "string"},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "string"},
+				},
+			},
+			Flagged: true,
+			ComparableValidation: &OneOf{
+				OneOfConfig: OneOfConfig{
+					RemovalPolicy: RemovalPolicyDisallow,
+				},
+			},
+		},
+		{
+			Name: "removed oneOf subschema, removal policy set to Allow, not flagged",
+			Old: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+					{Type: "string"},
+				},
+			},
+			New: &apiextensionsv1.JSONSchemaProps{
+				OneOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "string"},
+				},
+			},
+			Flagged: false,
+			ComparableValidation: &OneOf{
+				OneOfConfig: OneOfConfig{
+					RemovalPolicy: RemovalPolicyAllow,
+				},
+			},
 		},
 		{
 			Name: "new allowed oneOf subschema added, addition policy not set, flagged",
@@ -178,6 +218,7 @@ func TestValidateOneOfConfig(t *testing.T) {
 		cfg                *OneOfConfig
 		wantErr            error
 		wantAdditionPolicy AdditionPolicy
+		wantRemovalPolicy  RemovalPolicy
 	}{
 		{
 			name: "nil config",
@@ -187,16 +228,29 @@ func TestValidateOneOfConfig(t *testing.T) {
 			name:               "defaults addition policy",
 			cfg:                &OneOfConfig{},
 			wantAdditionPolicy: AdditionPolicyDisallow,
+			wantRemovalPolicy:  RemovalPolicyDisallow,
 		},
 		{
 			name:               "allows valid addition policies",
 			cfg:                &OneOfConfig{AdditionPolicy: AdditionPolicyAllow},
 			wantAdditionPolicy: AdditionPolicyAllow,
+			wantRemovalPolicy:  RemovalPolicyDisallow,
 		},
 		{
 			name:    "invalid addition policy",
 			cfg:     &OneOfConfig{AdditionPolicy: "invalid"},
 			wantErr: errUnknownAdditionPolicy,
+		},
+		{
+			name:               "allows valid removal policies",
+			cfg:                &OneOfConfig{RemovalPolicy: RemovalPolicyAllow},
+			wantAdditionPolicy: AdditionPolicyDisallow,
+			wantRemovalPolicy:  RemovalPolicyAllow,
+		},
+		{
+			name:    "invalid removal policy",
+			cfg:     &OneOfConfig{RemovalPolicy: "invalid"},
+			wantErr: errUnknownRemovalPolicy,
 		},
 	}
 
@@ -218,6 +272,10 @@ func TestValidateOneOfConfig(t *testing.T) {
 
 			if tc.cfg != nil && tc.cfg.AdditionPolicy != tc.wantAdditionPolicy {
 				t.Fatalf("expected addition policy %q, got %q", tc.wantAdditionPolicy, tc.cfg.AdditionPolicy)
+			}
+
+			if tc.cfg != nil && tc.cfg.RemovalPolicy != tc.wantRemovalPolicy {
+				t.Fatalf("expected removal policy %q, got %q", tc.wantRemovalPolicy, tc.cfg.RemovalPolicy)
 			}
 		})
 	}

--- a/test/oneofadded/a.yaml
+++ b/test/oneofadded/a.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: oneofexamples.example.com
+spec:
+  group: example.com
+  names:
+    kind: OneOfExample
+    listKind: OneOfExampleList
+    plural: oneofexamples
+    singular: oneofexample
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              port:
+                oneOf:
+                - type: integer

--- a/test/oneofadded/b.yaml
+++ b/test/oneofadded/b.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: oneofexamples.example.com
+spec:
+  group: example.com
+  names:
+    kind: OneOfExample
+    listKind: OneOfExampleList
+    plural: oneofexamples
+    singular: oneofexample
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              port:
+                oneOf:
+                - type: integer
+                - type: string

--- a/test/oneofadded/expected.json
+++ b/test/oneofadded/expected.json
@@ -9,7 +9,7 @@
       {
        "name": "oneOf",
        "errors": [
-        "allowed oneOf schemas added: [{\"type\":\"string\"}]"
+        "allowed oneOf schemas added: [\u0026JSONSchemaProps{ID:,Schema:,Ref:nil,Description:,Type:string,Format:,Title:,Default:nil,Maximum:nil,ExclusiveMaximum:false,Minimum:nil,ExclusiveMinimum:false,MaxLength:nil,MinLength:nil,Pattern:,MaxItems:nil,MinItems:nil,UniqueItems:false,MultipleOf:nil,Enum:[]JSON{},MaxProperties:nil,MinProperties:nil,Required:[],Items:nil,AllOf:[]JSONSchemaProps{},OneOf:[]JSONSchemaProps{},AnyOf:[]JSONSchemaProps{},Not:nil,Properties:map[string]JSONSchemaProps{},AdditionalProperties:nil,PatternProperties:map[string]JSONSchemaProps{},Dependencies:JSONSchemaDependencies{},AdditionalItems:nil,Definitions:JSONSchemaDefinitions{},ExternalDocs:nil,Example:nil,Nullable:false,XPreserveUnknownFields:nil,XEmbeddedResource:false,XIntOrString:false,XListMapKeys:[],XListType:nil,XMapType:nil,XValidations:[]ValidationRule{},}]"
        ]
       }
      ]

--- a/test/oneofadded/expected.json
+++ b/test/oneofadded/expected.json
@@ -1,0 +1,20 @@
+{
+ "sameVersionValidation": [
+  {
+   "version": "v1",
+   "propertyComparisons": [
+    {
+     "property": "^.spec.port",
+     "comparisonResults": [
+      {
+       "name": "oneOf",
+       "errors": [
+        "allowed oneOf schemas added: [{\"type\":\"string\"}]"
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/test/oneofnetnew/a.yaml
+++ b/test/oneofnetnew/a.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: oneofexamples.example.com
+spec:
+  group: example.com
+  names:
+    kind: OneOfExample
+    listKind: OneOfExampleList
+    plural: oneofexamples
+    singular: oneofexample
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              port:
+                type: integer

--- a/test/oneofnetnew/b.yaml
+++ b/test/oneofnetnew/b.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: oneofexamples.example.com
+spec:
+  group: example.com
+  names:
+    kind: OneOfExample
+    listKind: OneOfExampleList
+    plural: oneofexamples
+    singular: oneofexample
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              port:
+                oneOf:
+                - type: integer
+                - type: string

--- a/test/oneofnetnew/expected.json
+++ b/test/oneofnetnew/expected.json
@@ -1,0 +1,26 @@
+{
+ "sameVersionValidation": [
+  {
+   "version": "v1",
+   "propertyComparisons": [
+    {
+     "property": "^.spec.port",
+     "comparisonResults": [
+      {
+       "name": "oneOf",
+       "errors": [
+        "oneOf constraint added when there was none previously: [{\"type\":\"integer\"} {\"type\":\"string\"}]"
+       ]
+      },
+      {
+       "name": "type",
+       "errors": [
+        "type changed : \"integer\" -> \"\""
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/test/oneofnetnew/expected.json
+++ b/test/oneofnetnew/expected.json
@@ -9,13 +9,13 @@
       {
        "name": "oneOf",
        "errors": [
-        "oneOf constraint added when there was none previously: [{\"type\":\"integer\"} {\"type\":\"string\"}]"
+        "oneOf constraint added when there was none previously: [\u0026JSONSchemaProps{ID:,Schema:,Ref:nil,Description:,Type:integer,Format:,Title:,Default:nil,Maximum:nil,ExclusiveMaximum:false,Minimum:nil,ExclusiveMinimum:false,MaxLength:nil,MinLength:nil,Pattern:,MaxItems:nil,MinItems:nil,UniqueItems:false,MultipleOf:nil,Enum:[]JSON{},MaxProperties:nil,MinProperties:nil,Required:[],Items:nil,AllOf:[]JSONSchemaProps{},OneOf:[]JSONSchemaProps{},AnyOf:[]JSONSchemaProps{},Not:nil,Properties:map[string]JSONSchemaProps{},AdditionalProperties:nil,PatternProperties:map[string]JSONSchemaProps{},Dependencies:JSONSchemaDependencies{},AdditionalItems:nil,Definitions:JSONSchemaDefinitions{},ExternalDocs:nil,Example:nil,Nullable:false,XPreserveUnknownFields:nil,XEmbeddedResource:false,XIntOrString:false,XListMapKeys:[],XListType:nil,XMapType:nil,XValidations:[]ValidationRule{},} \u0026JSONSchemaProps{ID:,Schema:,Ref:nil,Description:,Type:string,Format:,Title:,Default:nil,Maximum:nil,ExclusiveMaximum:false,Minimum:nil,ExclusiveMinimum:false,MaxLength:nil,MinLength:nil,Pattern:,MaxItems:nil,MinItems:nil,UniqueItems:false,MultipleOf:nil,Enum:[]JSON{},MaxProperties:nil,MinProperties:nil,Required:[],Items:nil,AllOf:[]JSONSchemaProps{},OneOf:[]JSONSchemaProps{},AnyOf:[]JSONSchemaProps{},Not:nil,Properties:map[string]JSONSchemaProps{},AdditionalProperties:nil,PatternProperties:map[string]JSONSchemaProps{},Dependencies:JSONSchemaDependencies{},AdditionalItems:nil,Definitions:JSONSchemaDefinitions{},ExternalDocs:nil,Example:nil,Nullable:false,XPreserveUnknownFields:nil,XEmbeddedResource:false,XIntOrString:false,XListMapKeys:[],XListType:nil,XMapType:nil,XValidations:[]ValidationRule{},}]"
        ]
       },
       {
        "name": "type",
        "errors": [
-        "type changed : \"integer\" -> \"\""
+        "type changed : \"integer\" -\u003e \"\""
        ]
       }
      ]

--- a/test/oneofremoved/a.yaml
+++ b/test/oneofremoved/a.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: oneofexamples.example.com
+spec:
+  group: example.com
+  names:
+    kind: OneOfExample
+    listKind: OneOfExampleList
+    plural: oneofexamples
+    singular: oneofexample
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              port:
+                oneOf:
+                - type: integer
+                - type: string

--- a/test/oneofremoved/b.yaml
+++ b/test/oneofremoved/b.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: oneofexamples.example.com
+spec:
+  group: example.com
+  names:
+    kind: OneOfExample
+    listKind: OneOfExampleList
+    plural: oneofexamples
+    singular: oneofexample
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              port:
+                oneOf:
+                - type: integer

--- a/test/oneofremoved/expected.json
+++ b/test/oneofremoved/expected.json
@@ -17,7 +17,7 @@
       {
        "name": "oneOf",
        "errors": [
-        "allowed oneOf schemas removed: [{\"type\":\"string\"}]"
+        "allowed oneOf schemas removed: [\u0026JSONSchemaProps{ID:,Schema:,Ref:nil,Description:,Type:string,Format:,Title:,Default:nil,Maximum:nil,ExclusiveMaximum:false,Minimum:nil,ExclusiveMinimum:false,MaxLength:nil,MinLength:nil,Pattern:,MaxItems:nil,MinItems:nil,UniqueItems:false,MultipleOf:nil,Enum:[]JSON{},MaxProperties:nil,MinProperties:nil,Required:[],Items:nil,AllOf:[]JSONSchemaProps{},OneOf:[]JSONSchemaProps{},AnyOf:[]JSONSchemaProps{},Not:nil,Properties:map[string]JSONSchemaProps{},AdditionalProperties:nil,PatternProperties:map[string]JSONSchemaProps{},Dependencies:JSONSchemaDependencies{},AdditionalItems:nil,Definitions:JSONSchemaDefinitions{},ExternalDocs:nil,Example:nil,Nullable:false,XPreserveUnknownFields:nil,XEmbeddedResource:false,XIntOrString:false,XListMapKeys:[],XListType:nil,XMapType:nil,XValidations:[]ValidationRule{},}]"
        ]
       }
      ]
@@ -28,7 +28,7 @@
       {
        "name": "type",
        "errors": [
-        "type changed : \"string\" -> \"\""
+        "type changed : \"string\" -\u003e \"\""
        ]
       }
      ]

--- a/test/oneofremoved/expected.json
+++ b/test/oneofremoved/expected.json
@@ -1,0 +1,39 @@
+{
+ "crdValidation": [
+  {
+   "name": "existingFieldRemoval",
+   "errors": [
+    "removed field : v1.^.spec.port.oneOf[1]"
+   ]
+  }
+ ],
+ "sameVersionValidation": [
+  {
+   "version": "v1",
+   "propertyComparisons": [
+    {
+     "property": "^.spec.port",
+     "comparisonResults": [
+      {
+       "name": "oneOf",
+       "errors": [
+        "allowed oneOf schemas removed: [{\"type\":\"string\"}]"
+       ]
+      }
+     ]
+    },
+    {
+     "property": "^.spec.port.oneOf[1]",
+     "comparisonResults": [
+      {
+       "name": "type",
+       "errors": [
+        "type changed : \"string\" -> \"\""
+       ]
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}


### PR DESCRIPTION
#### What this PR does:

Adds a validation for the `oneOf` constraint on CRD properties to detect breaking changes:

- Adding a net-new `oneOf` constraint where there was none previously
- Removing an existing subschema from a `oneOf` constraint
- Adding a new subschema to a `oneOf` constraint

The validation includes a configurable `AdditionPolicy` (Allow/Disallow) to control whether
adding new subschemas to an existing `oneOf` constraint is flagged, defaulting to Disallow.
This addresses the reviewer feedback from #40 about allowing users to opt into accepting
loosening changes.

This is a re-implementation of #40, which was closed due to k8s bot inactivity lifecycle.

#### Which issue this PR is related to:

Fixes #25